### PR TITLE
[draft] cassandra plain simple authentication

### DIFF
--- a/src/marina_body.erl
+++ b/src/marina_body.erl
@@ -18,6 +18,12 @@ decode(#frame {flags = 1, body = Body, opcode = Opcode}) ->
     decode(Opcode, Body2).
 
 %% private
+decode(?OP_AUTHENTICATE, Body) ->
+    {ok, {authenticate, Body}};
+decode(?OP_AUTH_CHALLENGE, Body) ->
+    {ok, {authenticate_challenge, Body}};
+decode(?OP_AUTH_SUCCESS, Body) ->
+    {ok, {authenticate_success, Body}};
 decode(?OP_READY, _) ->
     {ok, undefined};
 decode(?OP_ERROR, Body) ->

--- a/src/marina_request.erl
+++ b/src/marina_request.erl
@@ -8,7 +8,8 @@
     execute/6,
     prepare/3,
     query/6,
-    startup/1
+    startup/1,
+    auth_response/3
 ]).
 
 %% public
@@ -78,6 +79,18 @@ startup(FrameFlags) ->
         opcode = ?OP_STARTUP,
         flags = FrameFlags2,
         body = [marina_types:encode_string_map(Body)]
+    }).
+
+-spec auth_response(binary(), binary(), [frame_flag()]) -> iolist().
+
+auth_response(Username, Password, FrameFlags) ->
+    FrameFlags2 = frame_flags(FrameFlags),
+    Body = <<0, Username/binary, 0, Password/binary>>,
+    marina_frame:encode(#frame {
+        stream = ?DEFAULT_STREAM,
+        opcode = ?OP_AUTH_RESPONSE,
+        flags = FrameFlags2,
+        body = [marina_types:encode_bytes(Body)]
     }).
 
 %% private


### PR DESCRIPTION
> I (fenollp) did not write this. Was just thinking others might be interested. Also I wanted to try whether a third party can create PRs and apparently yes!

This implements simple plaintext password authentication
for cassandra. Hope this helps anyone who has the same.

References:

* https://github.com/lpgauth/marina
* https://git-wip-us.apache.org/repos/asf?p=cassandra.git;a=blob_plain;f=doc/native_protocol_v3.spec
* https://wiki.apache.org/cassandra/ClientOptions