### PR TITLE
Add decode_number_list to marina_types

### DIFF
--- a/src/marina_types.erl
+++ b/src/marina_types.erl
@@ -10,6 +10,7 @@
     decode_long/1,
     decode_long_string/1,
     decode_long_string_set/1,
+    decode_number_list/1,
     decode_short/1,
     decode_short_bytes/1,
     decode_string/1,
@@ -60,6 +61,11 @@ decode_long_string(Bin) ->
 
 decode_long_string_set(<<Length:32, Rest/binary>>) ->
     decode_long_string_set(Rest, Length, []).
+
+-spec decode_number_list(binary()) -> {[integer()], binary()}.
+
+decode_number_list(<<Length:32, Rest/binary>>) ->
+    decode_number_list(Rest, Length, []).
 
 -spec decode_short(binary()) -> {integer(), binary()}.
 
@@ -173,6 +179,11 @@ encode_tinyint(Value) ->
     <<Value:8>>.
 
 %% private
+decode_number_list(Bin, 0, Acc) ->
+    {lists:reverse(Acc), Bin};
+decode_number_list(<<Pos:32, Number:(Pos * 8), Rest/binary>>, Length, Acc) ->
+    decode_number_list(Rest, Length - 1, [Number | Acc]).
+
 decode_long_string_set(Bin, 0, Acc) ->
     {lists:reverse(Acc), Bin};
 decode_long_string_set(Bin, Length, Acc) ->


### PR DESCRIPTION
Note that I named the new function `decode_number_list` instead of `decode_long_list` or `decode_int_list` because the cassandra protocol specifies the size of each element in the list (a bit wasteful but oh well) so it'll work for any integer types.