### PR TITLE
Float and String List Decoder

### DIFF
--- a/src/marina_token.erl
+++ b/src/marina_token.erl
@@ -6,10 +6,13 @@
 ]).
 
 %% public
--spec m3p(binary()) ->
+-spec m3p(integer() | binary()) ->
     integer().
 
-m3p(Key) ->
+m3p(Key) when is_integer(Key) ->
+    Key;
+
+m3p(Key) when is_binary(Key) ->
     <<Hash:64/signed-little-integer, _/binary>> =
         murmur:murmur3_cassandra_x64_128(Key),
     Hash.

--- a/src/marina_types.erl
+++ b/src/marina_types.erl
@@ -100,7 +100,7 @@ decode_string(Bin) ->
 
 -spec decode_string_list(binary()) -> {[binary()], binary()}.
 
-decode_string_list(<<Length:16, Rest/binary>>) ->
+decode_string_list(<<Length:32, Rest/binary>>) ->
     decode_string_list(Rest, Length, []).
 
 -spec decode_string_map(binary()) -> {[{binary(), binary()}], binary()}.
@@ -185,7 +185,7 @@ encode_string(Value) ->
 
 encode_string_list(Values) ->
     EncodedValues = [encode_string(Value) || Value <- Values],
-    iolist_to_binary([encode_short(length(Values)), EncodedValues]).
+    iolist_to_binary([encode_int(length(Values)), EncodedValues]).
 
 -spec encode_string_map([{binary(), binary()}]) -> binary().
 
@@ -216,7 +216,7 @@ decode_long_string_set(Bin, Length, Acc) ->
 
 decode_string_list(Bin, 0, Acc) ->
     {lists:reverse(Acc), Bin};
-decode_string_list(<<Pos:16, String:Pos/binary, Rest/binary>>, Length, Acc) ->
+decode_string_list(<<Pos:32, String:Pos/binary, Rest/binary>>, Length, Acc) ->
     decode_string_list(Rest, Length - 1, [String | Acc]).
 
 decode_string_map(Bin, 0, Acc) ->

--- a/src/marina_types.erl
+++ b/src/marina_types.erl
@@ -6,6 +6,8 @@
 
 -export([
     decode_bytes/1,
+    decode_double/1,
+    decode_float/1,
     decode_int/1,
     decode_long/1,
     decode_long_string/1,
@@ -21,6 +23,8 @@
     decode_uuid/1,
     encode_boolean/1,
     encode_bytes/1,
+    encode_double/1,
+    encode_float/1,
     encode_int/1,
     encode_list/1,
     encode_long/1,
@@ -40,6 +44,16 @@
 decode_bytes(<<255, 255, 255, 255, Rest/binary>>) ->
     {null, Rest};
 decode_bytes(<<Pos:32, Value:Pos/binary, Rest/binary>>) ->
+    {Value, Rest}.
+
+-spec decode_double(binary()) -> {float(), binary()}.
+
+decode_double(<<Value:64/float, Rest/binary>>) ->
+    {Value, Rest}.
+
+-spec decode_float(binary()) -> {float(), binary()}.
+
+decode_float(<<Value:32/float, Rest/binary>>) ->
     {Value, Rest}.
 
 -spec decode_int(binary()) -> {integer(), binary()}.
@@ -120,6 +134,16 @@ encode_bytes(null) ->
     <<255, 255, 255, 255>>;
 encode_bytes(Value) ->
     <<(encode_int(size(Value)))/binary, Value/binary>>.
+
+-spec encode_double(float()) -> binary().
+
+encode_double(Value) ->
+    <<Value:64/float>>.
+
+-spec encode_float(float()) -> binary().
+
+encode_float(Value) ->
+    <<Value:32/float>>.
 
 -spec encode_int(integer()) -> binary().
 


### PR DESCRIPTION
## Problem

We need support for the float and double type in marina. 

Also we found that the string list decoder did not match what marina was returning. The sizes were all 32 bits while the decoders is currently looking for 16 bits length. Additionally, the cassandra binary protocol documentation states that the sizes are 32 bits and not 16 (section 6.9 and 6.10).

Note that I have a feeling that the there are decoder that have the same problem (e.g. map decoder) but I don't currently have a setup for testing that so I don't want to mess with it.

Also, `marina_token` doesn't support none-binary keys so I fixed that as well as it's a relatively small and trivial fix. The logic is based on scylla's implementation which can be found below. The short version is that the integer is taken as is.
https://github.com/scylladb/scylladb/blob/master/dht/murmur3_partitioner.cc#L33-L36 

## Tests

Tested the decoding of doubles and it works as expected.

For string lists, this is the output of scylla for a string list:

```
<<0, 0, 0, 6, 0, 0, 0, 64, 53, 50, 100, 98, 101, 99, 99, 49, 50, 101, 101, 57,
  53, 49, 57, 98, 48, 54, 56, 51, 52, 55, 48, 52, 57, 56, 98, 101, 55, 98, 100,
  ...>>
```
You can pretty easily tell that the size of the list and the size of the string are both 32 bits and not 16. When decoded with the fixes here, everything comes out as expected.
