### PR TITLE
Implement and use marina_ring_utils:lookup_tree/1

### DIFF
--- a/src/marina_compiler.erl
+++ b/src/marina_compiler.erl
@@ -2,15 +2,14 @@
 -include("marina_internal.hrl").
 
 -export([
-    ring_utils/2
+    ring_utils/1
 ]).
 
 %% public
--spec ring_utils([{{integer(), integer()}, binary()}], tuple()) ->
-    ok.
+-spec ring_utils(tuple()) -> ok.
 
-ring_utils(Ring, Tree) ->
-    compile_and_load_forms(forms(Ring, Tree)),
+ring_utils(Tree) ->
+    compile_and_load_forms(forms(Tree)),
     ok.
 
 %% private
@@ -20,7 +19,7 @@ compile_and_load_forms(Forms) ->
     Filename = atom_to_list(Module) ++ ".erl",
     {module, Module} = code:load_binary(Module, Filename, Bin).
 
-forms(Ring, Tree) ->
+forms(Tree) ->
     Module = erl_syntax:attribute(erl_syntax:atom(module),
         [erl_syntax:atom(marina_ring_utils)]),
     ExportList = [
@@ -30,44 +29,9 @@ forms(Ring, Tree) ->
     Export = erl_syntax:attribute(erl_syntax:atom(export),
         [erl_syntax:list(ExportList)]),
     Function = erl_syntax:function(erl_syntax:atom(lookup),
-        lookup_clauses(Ring)),
-    Function2 = erl_syntax:function(erl_syntax:atom(lookup_tree),
         [tree_lookup_clause(Tree)]),
-    Mod = [Module, Export, Function, Function2],
+    Mod = [Module, Export, Function],
     [erl_syntax:revert(X) || X <- Mod].
-
-lookup_clause(Range, RpcAddress) ->
-    Patterns = [erl_syntax:variable('Token')],
-    Guard = range_guard(Range),
-    Body = [erl_syntax:tuple([erl_syntax:atom(ok),
-        erl_syntax:atom(marina_pool:node_id(RpcAddress))])],
-    erl_syntax:clause(Patterns, Guard, Body).
-
-lookup_clauses(Ring) ->
-    lookup_clauses(Ring, []).
-
-lookup_clauses([], Acc) ->
-    lists:reverse(Acc);
-lookup_clauses([{Range, HostId} | T], Acc) ->
-    lookup_clauses(T, [lookup_clause(Range, HostId) | Acc]).
-
-range_guard({undefined, End}) ->
-    Var = erl_syntax:variable('Token'),
-    Guard = erl_syntax:infix_expr(Var, erl_syntax:operator('=<'),
-        erl_syntax:integer(End)),
-    [Guard];
-range_guard({Start, undefined}) ->
-    Var = erl_syntax:variable('Token'),
-    Guard = erl_syntax:infix_expr(Var, erl_syntax:operator('>'),
-        erl_syntax:integer(Start)),
-    [Guard];
-range_guard({Start, End}) ->
-    Var = erl_syntax:variable('Token'),
-    Guard1 = erl_syntax:infix_expr(Var, erl_syntax:operator('>'),
-        erl_syntax:integer(Start)),
-    Guard2 = erl_syntax:infix_expr(Var, erl_syntax:operator('=<'),
-        erl_syntax:integer(End)),
-    [Guard1, Guard2].
 
 tree_lookup_clause(Tree) ->
     Var = erl_syntax:variable('Token'),

--- a/src/marina_ring.erl
+++ b/src/marina_ring.erl
@@ -2,7 +2,7 @@
 -include("marina_internal.hrl").
 
 -ignore_xref([
-    {marina_ring_utils, lookup, 1}
+    {marina_ring_utils, lookup_tree, 1}
 ]).
 
 -dialyzer({nowarn_function, lookup/1}).
@@ -21,14 +21,16 @@ build(Nodes) ->
         {Tokens2, <<>>} = marina_types:decode_long_string_set(Tokens),
         [{binary_to_integer(Token), RpcAddress} || Token <- Tokens2]
     end, Nodes),
-    Ranges = ranges(lists:usort(lists:flatten(Ring))),
-    marina_compiler:ring_utils(Ranges).
+    Sorted = lists:usort(lists:flatten(Ring)),
+    Tree = build_tree(Sorted),
+    Ranges = ranges(Sorted),
+    marina_compiler:ring_utils(Ranges, Tree).
 
 -spec lookup(routing_key()) ->
     atom().
 
 lookup(Key) ->
-    marina_ring_utils:lookup(marina_token:m3p(Key)).
+    marina_ring_utils:lookup_tree(marina_token:m3p(Key)).
 
 %% private
 ranges(Ring) ->
@@ -39,3 +41,19 @@ ranges([], LastToken, Acc) ->
     Ranges ++ [{{LastToken, undefined}, HostId}];
 ranges([{Token, HostId} | T], LastToken, Acc) ->
     ranges(T, Token, [{{LastToken, Token}, HostId} | Acc]).
+
+build_tree(Sorted) ->
+    [{_, First} | _] = Sorted,
+    Input = Sorted ++ [{undefined, First}],
+    build_tree(Input, length(Input)).
+
+build_tree([{Token, RpcAddress}], 1) ->
+    [{Token, RpcAddress}];
+build_tree([{LToken, LRpc}, {RToken, RRpc}], 2) ->
+    [{LToken, LRpc}, {RToken, RRpc}];
+build_tree(Bounds, Length) ->
+    LLength = Length div 2,
+    RLength = Length - LLength - 1,
+    {LBounds, RBounds0} = lists:split(LLength, Bounds),
+    [{Token, RpcAddress} | RBounds] = RBounds0,
+    {{Token, RpcAddress}, build_tree(LBounds, LLength), build_tree(RBounds, RLength)}.

--- a/src/marina_ring.erl
+++ b/src/marina_ring.erl
@@ -23,8 +23,7 @@ build(Nodes) ->
     end, Nodes),
     Sorted = lists:usort(lists:flatten(Ring)),
     Tree = build_tree(Sorted),
-    Ranges = ranges(Sorted),
-    marina_compiler:ring_utils(Ranges, Tree).
+    marina_compiler:ring_utils(Tree).
 
 -spec lookup(routing_key()) ->
     atom().
@@ -33,15 +32,6 @@ lookup(Key) ->
     marina_ring_utils:lookup_tree(marina_token:m3p(Key)).
 
 %% private
-ranges(Ring) ->
-    ranges(Ring, undefined, []).
-
-ranges([], LastToken, Acc) ->
-    [{_Range, HostId} | _] = Ranges = lists:reverse(Acc),
-    Ranges ++ [{{LastToken, undefined}, HostId}];
-ranges([{Token, HostId} | T], LastToken, Acc) ->
-    ranges(T, Token, [{{LastToken, Token}, HostId} | Acc]).
-
 build_tree(Sorted) ->
     [{_, First} | _] = Sorted,
     Input = Sorted ++ [{undefined, First}],


### PR DESCRIPTION
This PR changes marina_ring_utils to export lookup_tree/1, which uses binary search through nested case expressions instead of lookup/1's approach of using function heads.

In production, lookup_tree/1 appears to execute much faster than lookup/1.

Before:
![image](https://github.com/user-attachments/assets/f915dc15-2a75-4f60-bf40-7cdcc0721627)

After:
![image](https://github.com/user-attachments/assets/2dcbfe8d-4dde-4b65-8f03-d46c2f973820)

As far as I can tell, over the weekend, remote reads to Scylla have not increased (when not running bulk load jobs), making me suspect that the implementation of lookup_tree/1 is correct and identical to lookup/1.

Would you like me to remove lookup/1, or replace it with lookup_tree?