### PR TITLE
Bump lz4 to pick up Darwin arm64 build fix

### DIFF
--- a/rebar.lock
+++ b/rebar.lock
@@ -9,7 +9,7 @@
   0},
  {<<"lz4">>,
   {git,"https://github.com/lpgauth/erlang-lz4.git",
-       {ref,"30ac242cf8f6ec9ef097f494ae87f6295039ffd4"}},
+       {ref,"9f2368addb07af0ea573fd1f1afd53e17adbea23"}},
   0},
  {<<"metal">>,{pkg,<<"metal">>,<<"0.1.1">>},1},
  {<<"murmur">>,


### PR DESCRIPTION
## Summary

`lz4` dep's `c_src/Makefile` hardcoded `-arch x86_64` on Darwin, producing an x86_64 NIF that failed to load on Apple Silicon. Any `compression=true` codepath then crashes on `lz4:uncompress/2` — which broke `marina_compression_test_` locally on arm64 and caused the pool-server bootstrap to silently fail whenever the compression app env was set.

Upstream fix landed on erlang-lz4's `rebar3` branch as commit `9f2368a` (drop the `-arch` flag so `cc` picks the host architecture). This bumps `rebar.lock` to that commit.

With the bump, marina's eunit suite runs 14/14 green against Scylla 6.2.3 including `marina_compression_test_`.