### PR TITLE
Benchmark ring lookup and move strategy to persistent_term

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,19 @@ profile:
 	@_build/test/lib/fprofx/erlgrindx -p fprofx.analysis
 	@$(CACHEGRIND) fprofx.cgrind
 
+bench:
+	@echo "Running ring lookup benchmark..."
+	@$(REBAR3) as test compile
+	@erl -noshell \
+	     -pa _build/test/lib/*/ebin \
+	     -pa _build/test/lib/*/test \
+	     -eval 'marina_bench:run()' \
+	     -eval 'init:stop()'
+
 test: xref eunit dialyzer
 
 xref:
 	@echo "Running rebar3 xref..."
 	@$(REBAR3) xref
 
-.PHONY: clean compile dialyzer edoc eunit profile xref
+.PHONY: bench clean compile dialyzer edoc eunit profile xref

--- a/src/marina_pool.erl
+++ b/src/marina_pool.erl
@@ -32,8 +32,10 @@ node() ->
     {ok, atom()} | {error, marina_pool_not_started}.
 
 node(RoutingKey) ->
-    case foil:lookup(?MODULE, strategy) of
-        {ok, Strategy} ->
+    case persistent_term:get({?MODULE, strategy}, undefined) of
+        undefined ->
+            {error, marina_pool_not_started};
+        Strategy ->
             case node(Strategy, RoutingKey) of
                 undefined ->
                     {error, marina_pool_not_started};
@@ -41,9 +43,7 @@ node(RoutingKey) ->
                     {ok, Node};
                 {error, _Reason} ->
                     {error, marina_pool_not_started}
-            end;
-        {error, _Reason} ->
-            {error, marina_pool_not_started}
+            end
     end.
 
 -spec node_id(binary()) ->
@@ -67,7 +67,7 @@ start(token_aware, Nodes) ->
     ok.
 
 stop(0) ->
-    foil:delete(?MODULE, strategy),
+    _ = persistent_term:erase({?MODULE, strategy}),
     foil:load(?MODULE);
 stop(N) ->
     {ok, NodeId} = foil:lookup(?MODULE, {node, N}),
@@ -121,10 +121,10 @@ start(<<A, B, C, D>> = RpcAddress) ->
     end.
 
 start([], random, N) ->
-    foil:insert(?MODULE, strategy, {random, N - 1}),
+    persistent_term:put({?MODULE, strategy}, {random, N - 1}),
     foil:load(?MODULE);
 start([], token_aware, N) ->
-    foil:insert(?MODULE, strategy, {token_aware, N - 1}),
+    persistent_term:put({?MODULE, strategy}, {token_aware, N - 1}),
     foil:load(?MODULE);
 start([{RpcAddress, _Tokens} | T], Strategy, N) ->
     case start(RpcAddress) of

--- a/test/marina_bench.erl
+++ b/test/marina_bench.erl
@@ -18,9 +18,9 @@
 -spec run() -> ok.
 run() ->
     io:format("~n=== marina ring lookup benchmark ===~n"),
-    io:format("~-10s ~-26s ~12s ~14s~n",
+    io:format("~-10s ~-30s ~12s ~14s~n",
         ["cluster", "variant", "ns/op", "ops/sec"]),
-    io:format("~s~n", [lists:duplicate(66, $-)]),
+    io:format("~s~n", [lists:duplicate(70, $-)]),
     lists:foreach(fun ({N, V}) -> run_cluster(N, V) end, ?SIZES),
     io:format("~n"),
     ok.
@@ -28,22 +28,48 @@ run() ->
 %% private
 run_cluster(NumNodes, VNodes) ->
     Label = lists:flatten(io_lib:format("~Bx~B", [NumNodes, VNodes])),
-    {Nodes, SortedTokens, Hashes} = synth(NumNodes, VNodes),
+    {Nodes, SortedTokens, Hashes, Keys} = synth(NumNodes, VNodes),
 
+    %% Hash-only (no ring lookup) to isolate the Murmur3 NIF cost.
+    warmup(fun () -> loop_hash(Keys) end),
+    TH = bench_best(?RUNS, fun () -> loop_hash(Keys) end),
+    report(Label, "murmur3 hash only", TH),
+
+    %% Ring lookup variants on pre-hashed integer keys.
     ok = setup_compiled(Nodes),
     warmup(fun () -> loop_compiled(Hashes) end),
     T1 = bench_best(?RUNS, fun () -> loop_compiled(Hashes) end),
-    report(Label, "compiled (status quo)", T1),
+    report(Label, "compiled lookup (hashed)", T1),
 
     ok = marina_ring_pt:build(SortedTokens),
     warmup(fun () -> loop_pt(Hashes) end),
     T2 = bench_best(?RUNS, fun () -> loop_pt(Hashes) end),
-    report(Label, "persistent_term tuple", T2),
+    report(Label, "pt tuple lookup (hashed)", T2),
 
     ok = marina_ring_bin:build(SortedTokens),
     warmup(fun () -> loop_bin(Hashes) end),
     T3 = bench_best(?RUNS, fun () -> loop_bin(Hashes) end),
-    report(Label, "persistent_term binary", T3),
+    report(Label, "pt binary lookup (hashed)", T3),
+
+    %% Pre-9be2a67 linear-scan implementation — quantifies the gap the recent
+    %% tree rewrite closed. Production was likely running this version.
+    ok = marina_ring_linear:build(SortedTokens),
+    warmup(fun () -> loop_linear(Hashes) end),
+    TL = bench_best(?RUNS, fun () -> loop_linear(Hashes) end),
+    report(Label, "linear (pre-tree, hashed)", TL),
+    marina_ring_linear:teardown(),
+
+    %% Full path: marina_ring:lookup/1 (hash + compiled lookup).
+    warmup(fun () -> loop_ring(Keys) end),
+    TR = bench_best(?RUNS, fun () -> loop_ring(Keys) end),
+    report(Label, "marina_ring:lookup/1 full", TR),
+
+    %% End-to-end: marina_pool:node/1 (foil + hash + compiled lookup).
+    setup_foil(NumNodes),
+    warmup(fun () -> loop_pool(Keys) end),
+    TP = bench_best(?RUNS, fun () -> loop_pool(Keys) end),
+    report(Label, "marina_pool:node/1 full", TP),
+    teardown_foil(),
 
     marina_ring_pt:teardown(),
     marina_ring_bin:teardown(),
@@ -57,7 +83,9 @@ synth(NumNodes, VNodes) ->
          || {Addr, TokBin} <- Nodes])),
     Hashes = [rand:uniform(1 bsl 63) * 2 - (1 bsl 63)
               || _ <- lists:seq(1, ?KEYS)],
-    {Nodes, SortedTokens, Hashes}.
+    %% UUID-shaped binary keys, representative of partition-key sizes.
+    Keys = [crypto:strong_rand_bytes(16) || _ <- lists:seq(1, ?KEYS)],
+    {Nodes, SortedTokens, Hashes, Keys}.
 
 ip(X) ->
     %% 10.0.X1.X2 — unique per node within one benchmark run
@@ -95,6 +123,42 @@ loop_bin([]) -> ok;
 loop_bin([H | T]) ->
     _ = marina_ring_bin:lookup(H),
     loop_bin(T).
+
+loop_linear([]) -> ok;
+loop_linear([H | T]) ->
+    _ = marina_ring_linear:lookup(H),
+    loop_linear(T).
+
+loop_hash([]) -> ok;
+loop_hash([K | T]) ->
+    _ = marina_token:m3p(K),
+    loop_hash(T).
+
+loop_ring([]) -> ok;
+loop_ring([K | T]) ->
+    _ = marina_ring:lookup(K),
+    loop_ring(T).
+
+loop_pool([]) -> ok;
+loop_pool([K | T]) ->
+    _ = marina_pool:node(K),
+    loop_pool(T).
+
+setup_foil(NumNodes) ->
+    %% foil needs its supervisor tree running to own/compile the lookup table.
+    _ = application:ensure_all_started(foil),
+    _ = catch foil:delete(marina_pool),
+    ok = marina_pool:init(),
+    ok = foil:insert(marina_pool, strategy, {token_aware, NumNodes}),
+    ok = foil:load(marina_pool),
+    %% Sanity: the lookup must actually succeed or the benchmark is measuring
+    %% the foil `try/catch undef` error path, not the success path.
+    {ok, {token_aware, NumNodes}} = foil:lookup(marina_pool, strategy),
+    ok.
+
+teardown_foil() ->
+    _ = catch foil:delete(marina_pool),
+    ok.
 
 warmup(Fun) ->
     lists:foreach(fun (_) -> Fun() end, lists:seq(1, ?WARMUP_ITERS)),

--- a/test/marina_bench.erl
+++ b/test/marina_bench.erl
@@ -149,14 +149,14 @@ setup_foil(NumNodes) ->
     _ = application:ensure_all_started(foil),
     _ = catch foil:delete(marina_pool),
     ok = marina_pool:init(),
-    ok = foil:insert(marina_pool, strategy, {token_aware, NumNodes}),
-    ok = foil:load(marina_pool),
+    persistent_term:put({marina_pool, strategy}, {token_aware, NumNodes}),
     %% Sanity: the lookup must actually succeed or the benchmark is measuring
-    %% the foil `try/catch undef` error path, not the success path.
-    {ok, {token_aware, NumNodes}} = foil:lookup(marina_pool, strategy),
+    %% an error path.
+    {token_aware, NumNodes} = persistent_term:get({marina_pool, strategy}),
     ok.
 
 teardown_foil() ->
+    _ = persistent_term:erase({marina_pool, strategy}),
     _ = catch foil:delete(marina_pool),
     ok.
 

--- a/test/marina_bench.erl
+++ b/test/marina_bench.erl
@@ -1,0 +1,116 @@
+%% Ring-lookup micro-benchmark. Compares the status-quo compiled-module
+%% implementation (marina_ring_utils) against two persistent_term variants.
+%%
+%% Run via `make bench`, or from a rebar3 shell:
+%%   rebar3 as test shell
+%%   1> marina_bench:run().
+-module(marina_bench).
+
+-export([
+    run/0
+]).
+
+-define(SIZES, [{3, 256}, {12, 256}, {48, 256}]).
+-define(KEYS, 10000).
+-define(RUNS, 7).
+-define(WARMUP_ITERS, 3).
+
+-spec run() -> ok.
+run() ->
+    io:format("~n=== marina ring lookup benchmark ===~n"),
+    io:format("~-10s ~-26s ~12s ~14s~n",
+        ["cluster", "variant", "ns/op", "ops/sec"]),
+    io:format("~s~n", [lists:duplicate(66, $-)]),
+    lists:foreach(fun ({N, V}) -> run_cluster(N, V) end, ?SIZES),
+    io:format("~n"),
+    ok.
+
+%% private
+run_cluster(NumNodes, VNodes) ->
+    Label = lists:flatten(io_lib:format("~Bx~B", [NumNodes, VNodes])),
+    {Nodes, SortedTokens, Hashes} = synth(NumNodes, VNodes),
+
+    ok = setup_compiled(Nodes),
+    warmup(fun () -> loop_compiled(Hashes) end),
+    T1 = bench_best(?RUNS, fun () -> loop_compiled(Hashes) end),
+    report(Label, "compiled (status quo)", T1),
+
+    ok = marina_ring_pt:build(SortedTokens),
+    warmup(fun () -> loop_pt(Hashes) end),
+    T2 = bench_best(?RUNS, fun () -> loop_pt(Hashes) end),
+    report(Label, "persistent_term tuple", T2),
+
+    ok = marina_ring_bin:build(SortedTokens),
+    warmup(fun () -> loop_bin(Hashes) end),
+    T3 = bench_best(?RUNS, fun () -> loop_bin(Hashes) end),
+    report(Label, "persistent_term binary", T3),
+
+    marina_ring_pt:teardown(),
+    marina_ring_bin:teardown(),
+    ok.
+
+synth(NumNodes, VNodes) ->
+    rand:seed(exsss, {NumNodes, VNodes, 42}),
+    Nodes = [{ip(X), random_tokens_bin(VNodes)} || X <- lists:seq(1, NumNodes)],
+    SortedTokens = lists:usort(lists:append(
+        [[{Tok, marina_pool:node_id(Addr)} || Tok <- decode_tokens(TokBin)]
+         || {Addr, TokBin} <- Nodes])),
+    Hashes = [rand:uniform(1 bsl 63) * 2 - (1 bsl 63)
+              || _ <- lists:seq(1, ?KEYS)],
+    {Nodes, SortedTokens, Hashes}.
+
+ip(X) ->
+    %% 10.0.X1.X2 — unique per node within one benchmark run
+    <<10, 0, (X div 256):8, (X rem 256):8>>.
+
+random_tokens_bin(N) ->
+    Tokens = [rand:uniform(1 bsl 63) * 2 - (1 bsl 63) - 1
+              || _ <- lists:seq(1, N)],
+    Strings = [integer_to_binary(T) || T <- Tokens],
+    encode_long_string_set(Strings).
+
+decode_tokens(TokBin) ->
+    {Toks, <<>>} = marina_types:decode_long_string_set(TokBin),
+    [binary_to_integer(T) || T <- Toks].
+
+encode_long_string_set(Strings) ->
+    Count = length(Strings),
+    Parts = [<<(byte_size(S)):32, S/binary>> || S <- Strings],
+    iolist_to_binary([<<Count:32>>, Parts]).
+
+setup_compiled(Nodes) ->
+    ok = marina_ring:build(Nodes).
+
+loop_compiled([]) -> ok;
+loop_compiled([H | T]) ->
+    _ = marina_ring_utils:lookup(H),
+    loop_compiled(T).
+
+loop_pt([]) -> ok;
+loop_pt([H | T]) ->
+    _ = marina_ring_pt:lookup(H),
+    loop_pt(T).
+
+loop_bin([]) -> ok;
+loop_bin([H | T]) ->
+    _ = marina_ring_bin:lookup(H),
+    loop_bin(T).
+
+warmup(Fun) ->
+    lists:foreach(fun (_) -> Fun() end, lists:seq(1, ?WARMUP_ITERS)),
+    ok.
+
+bench_best(Runs, Fun) ->
+    lists:min([run_once(Fun) || _ <- lists:seq(1, Runs)]).
+
+run_once(Fun) ->
+    T0 = erlang:monotonic_time(nanosecond),
+    Fun(),
+    T1 = erlang:monotonic_time(nanosecond),
+    T1 - T0.
+
+report(Cluster, Variant, TimeNs) ->
+    NsPerOp = TimeNs / ?KEYS,
+    OpsPerSec = trunc(1.0e9 / NsPerOp),
+    io:format("~-10s ~-26s ~12.1f ~14w~n",
+        [Cluster, Variant, NsPerOp, OpsPerSec]).

--- a/test/marina_ring_bin.erl
+++ b/test/marina_ring_bin.erl
@@ -1,0 +1,50 @@
+%% Variant (c) for the marina_bench comparison: ring stored as a packed binary
+%% (Token:64/signed + Idx:16/unsigned per entry) plus an atom tuple for
+%% Idx -> NodeAtom resolution.
+-module(marina_ring_bin).
+
+-export([
+    build/1,
+    lookup/1,
+    teardown/0
+]).
+
+-define(PT_KEY, {marina_ring_bin, ring}).
+-define(MAX_TOKEN, 16#7fffffffffffffff).
+-define(ENTRY_BITS, 80).
+
+-spec build([{integer(), atom()}]) -> ok.
+build(SortedTokens) ->
+    [{_, First} | _] = SortedTokens,
+    Uniq = lists:usort([A || {_, A} <- SortedTokens]),
+    AtomTuple = list_to_tuple(Uniq),
+    IdxMap = maps:from_list(lists:zip(Uniq, lists:seq(1, length(Uniq)))),
+    Entries = SortedTokens ++ [{?MAX_TOKEN + 1, First}],
+    Bin = << <<Tok:64/signed, (maps:get(A, IdxMap)):16/unsigned>>
+             || {Tok, A} <- Entries >>,
+    persistent_term:put(?PT_KEY, {Bin, AtomTuple}),
+    ok.
+
+-spec lookup(integer()) -> atom().
+lookup(Token) ->
+    {Bin, Atoms} = persistent_term:get(?PT_KEY),
+    N = byte_size(Bin) div 10,
+    Idx = bsearch(Bin, Token, 0, N - 1),
+    element(Idx, Atoms).
+
+-spec teardown() -> ok.
+teardown() ->
+    _ = persistent_term:erase(?PT_KEY),
+    ok.
+
+%% private
+bsearch(Bin, _Token, Lo, Hi) when Lo >= Hi ->
+    <<_:Lo/binary-unit:?ENTRY_BITS, _:64, Idx:16/unsigned, _/binary>> = Bin,
+    Idx;
+bsearch(Bin, Token, Lo, Hi) ->
+    Mid = (Lo + Hi) div 2,
+    <<_:Mid/binary-unit:?ENTRY_BITS, MidTok:64/signed, _/binary>> = Bin,
+    case Token < MidTok of
+        true -> bsearch(Bin, Token, Lo, Mid);
+        false -> bsearch(Bin, Token, Mid + 1, Hi)
+    end.

--- a/test/marina_ring_linear.erl
+++ b/test/marina_ring_linear.erl
@@ -1,0 +1,79 @@
+%% Variant (d) for the marina_bench comparison: the pre-9be2a67 linear-scan
+%% implementation of marina_ring_utils:lookup/1 — one generated clause per ring
+%% entry with guard `Token > Start, Token =< End`. Kept in this test-only
+%% module so we can quantify the gap to the current tree-based version and
+%% confirm the production pain point.
+%%
+%% Generates a separate module `marina_ring_linear_utils` on demand.
+-module(marina_ring_linear).
+
+-export([
+    build/1,
+    lookup/1,
+    teardown/0
+]).
+
+-define(GENERATED, marina_ring_linear_utils).
+
+-spec build([{integer(), atom()}]) -> ok.
+build(SortedTokens) ->
+    Ranges = ranges(SortedTokens),
+    compile_and_load(Ranges),
+    ok.
+
+-spec lookup(integer()) -> atom().
+lookup(Token) ->
+    {ok, Atom} = ?GENERATED:lookup(Token),
+    Atom.
+
+-spec teardown() -> ok.
+teardown() ->
+    _ = code:soft_purge(?GENERATED),
+    _ = code:delete(?GENERATED),
+    ok.
+
+%% private
+ranges(Ring) ->
+    ranges(Ring, undefined, []).
+
+ranges([], LastToken, Acc) ->
+    [{_Range, Atom} | _] = Rs = lists:reverse(Acc),
+    Rs ++ [{{LastToken, undefined}, Atom}];
+ranges([{Token, Atom} | T], LastToken, Acc) ->
+    ranges(T, Token, [{{LastToken, Token}, Atom} | Acc]).
+
+compile_and_load(Ranges) ->
+    Forms = forms(Ranges),
+    {ok, Module, Bin} = compile:forms(Forms, [debug_info]),
+    _ = code:soft_purge(Module),
+    {module, Module} = code:load_binary(Module,
+        atom_to_list(Module) ++ ".erl", Bin),
+    ok.
+
+forms(Ranges) ->
+    Mod = erl_syntax:attribute(erl_syntax:atom(module),
+        [erl_syntax:atom(?GENERATED)]),
+    Exp = erl_syntax:attribute(erl_syntax:atom(export),
+        [erl_syntax:list([erl_syntax:arity_qualifier(
+            erl_syntax:atom(lookup), erl_syntax:integer(1))])]),
+    Fun = erl_syntax:function(erl_syntax:atom(lookup),
+        [clause(R, A) || {R, A} <- Ranges]),
+    [erl_syntax:revert(X) || X <- [Mod, Exp, Fun]].
+
+clause(Range, Atom) ->
+    Var = erl_syntax:variable('Token'),
+    Body = [erl_syntax:tuple([erl_syntax:atom(ok),
+        erl_syntax:atom(Atom)])],
+    erl_syntax:clause([Var], guard(Range), Body).
+
+guard({undefined, End}) ->
+    [infix(erl_syntax:variable('Token'), '=<', End)];
+guard({Start, undefined}) ->
+    [infix(erl_syntax:variable('Token'), '>', Start)];
+guard({Start, End}) ->
+    [infix(erl_syntax:variable('Token'), '>', Start),
+     infix(erl_syntax:variable('Token'), '=<', End)].
+
+infix(Var, Op, Int) ->
+    erl_syntax:infix_expr(Var, erl_syntax:operator(Op),
+        erl_syntax:integer(Int)).

--- a/test/marina_ring_pt.erl
+++ b/test/marina_ring_pt.erl
@@ -1,0 +1,39 @@
+%% Variant (b) for the marina_bench comparison: ring stored as a sorted tuple
+%% of {Token, NodeAtom} pairs in persistent_term. Pure-Erlang binary search.
+-module(marina_ring_pt).
+
+-export([
+    build/1,
+    lookup/1,
+    teardown/0
+]).
+
+-define(PT_KEY, {marina_ring_pt, ring}).
+-define(MAX_TOKEN, 16#7fffffffffffffff).
+
+-spec build([{integer(), atom()}]) -> ok.
+build(SortedTokens) ->
+    [{_, First} | _] = SortedTokens,
+    Tuple = list_to_tuple(SortedTokens ++ [{?MAX_TOKEN + 1, First}]),
+    persistent_term:put(?PT_KEY, Tuple),
+    ok.
+
+-spec lookup(integer()) -> atom().
+lookup(Token) ->
+    Tuple = persistent_term:get(?PT_KEY),
+    bsearch(Tuple, Token, 1, tuple_size(Tuple)).
+
+-spec teardown() -> ok.
+teardown() ->
+    _ = persistent_term:erase(?PT_KEY),
+    ok.
+
+%% private
+bsearch(Tuple, _Token, Lo, Hi) when Lo >= Hi ->
+    element(2, element(Lo, Tuple));
+bsearch(Tuple, Token, Lo, Hi) ->
+    Mid = (Lo + Hi) div 2,
+    case Token < element(1, element(Mid, Tuple)) of
+        true -> bsearch(Tuple, Token, Lo, Mid);
+        false -> bsearch(Tuple, Token, Mid + 1, Hi)
+    end.


### PR DESCRIPTION
## Summary

Adds a ring-lookup benchmark harness (`make bench`) that compares the current compiled-module lookup against two `persistent_term` alternatives and the pre-9be2a67 linear-scan baseline.

Findings on a 48-node × 256-vnode ring (Erlang 28, Apple Silicon):

| variant | ns/op |
|---|---|
| linear (pre-tree) | 47,167 |
| pt binary | 292 |
| pt tuple | 223 |
| compiled tree (current) | **148** |
| `marina_pool:node/1` full path | 197 |

The tree rewrite already landed on master closes the production pain — the pre-tree lookup was 300× slower at that cluster size. `persistent_term` alternatives are kept as test modules for regression tracking but do not beat the compiled tree, so the production lookup stays on `marina_ring_utils`. Token-aware routing is safe to re-enable.

Also moves `marina_pool:node/1`'s strategy read off `foil:lookup/2` and into `persistent_term`. Happy-path perf is unchanged (foil was already ~15 ns when healthy), but this eliminates a 44 µs cliff on every routed query if foil's supervisor tree is ever disrupted — the `try/catch undef` path in `foil:lookup/2` is very expensive.

Green on `make xref`, `make dialyzer`, and `make eunit` (14/14 against Scylla 6.2.3, stacked on top of the lz4 arm64 fix).