### PR TITLE
Negotiate CQL native protocol v4

### DIFF
--- a/include/marina.hrl
+++ b/include/marina.hrl
@@ -19,7 +19,7 @@
 }).
 
 -record(frame, {
-    flags  :: 0 | 1,
+    flags  :: byte(),
     stream :: integer(),
     opcode :: non_neg_integer(),
     body   :: iolist() | binary()

--- a/include/marina_internal.hrl
+++ b/include/marina_internal.hrl
@@ -40,7 +40,7 @@
 -define(HEADER_SIZE, 9).
 -define(LZ4_COMPRESSION, {<<"COMPRESSION">>, <<"lz4">>}).
 -define(MAX_STREAM_ID, 32768).
--define(PROTO_VERSION, 3).
+-define(PROTO_VERSION, 4).
 
 -define(OP_ERROR, 16#00).
 -define(OP_STARTUP, 16#01).

--- a/src/marina_body.erl
+++ b/src/marina_body.erl
@@ -46,7 +46,7 @@ decode(?OP_RESULT, <<3:32/integer, Rest/binary>>) ->
     {ok, Keyspace};
 decode(?OP_RESULT, <<4:32/integer, Rest/binary>>) ->
     {Id, Rest2} = marina_types:decode_short_bytes(Rest),
-    {_Metadata, Rest3} = decode_result_metadata(Rest2),
+    {_Metadata, Rest3} = decode_prepared_metadata(Rest2),
     {_ResultMetadata, <<>>} = decode_result_metadata(Rest3),
     {ok, Id};
 decode(?OP_RESULT, <<5:32/integer, Rest/binary>>) ->
@@ -191,6 +191,28 @@ decode_result_paging_state(Rest, false) ->
 decode_result_metadata(<<Flags:32/integer, ColumnsCount:32/integer,
     Rest/binary>>) ->
 
+    {GlobalTableSpec, HasMorePages, NoMetaData} = decode_result_flags(Flags),
+    {PagingState, Rest2} = decode_result_paging_state(Rest, HasMorePages),
+    {Columns, Rest3} = case NoMetaData of
+        true -> {[], Rest2};
+        false ->
+            decode_columns_metadata(Rest2, ColumnsCount, GlobalTableSpec)
+    end,
+
+    {#result_metadata {
+        columns_count = ColumnsCount,
+        columns = Columns,
+        paging_state = PagingState
+    }, Rest3}.
+
+%% PREPARED result metadata (v4+) carries a pk_count + pk_indexes preamble
+%% that the plain ROWS result_metadata does not. marina does not consume the
+%% pk info for routing, so we skip it and fall through to the shared tail.
+decode_prepared_metadata(<<Flags:32/integer, ColumnsCount:32/integer,
+    PkCount:32/integer, PkRest/binary>>) ->
+
+    PkSkip = PkCount * 2,
+    <<_PkIndexes:PkSkip/binary, Rest/binary>> = PkRest,
     {GlobalTableSpec, HasMorePages, NoMetaData} = decode_result_flags(Flags),
     {PagingState, Rest2} = decode_result_paging_state(Rest, HasMorePages),
     {Columns, Rest3} = case NoMetaData of

--- a/src/marina_body.erl
+++ b/src/marina_body.erl
@@ -11,11 +11,12 @@
 %% public
 -spec decode(frame()) -> {ok, term()} | {error, atom()}.
 
-decode(#frame {flags = 0, body = Body, opcode = Opcode}) ->
-    decode(Opcode, Body);
-decode(#frame {flags = 1, body = Body, opcode = Opcode}) ->
-    {ok, Body2} = marina_utils:unpack(Body),
-    decode(Opcode, Body2).
+decode(#frame {flags = Flags, body = Body, opcode = Opcode}) ->
+    Body1 = maybe_decompress(Flags, Body),
+    Body2 = skip_tracing(Flags, Body1),
+    Body3 = skip_custom_payload(Flags, Body2),
+    Body4 = skip_warnings(Flags, Body3),
+    decode(Opcode, Body4).
 
 %% private
 decode(?OP_ERROR, Body) ->
@@ -69,6 +70,45 @@ decode(?OP_RESULT, <<5:32/integer, Rest/binary>>) ->
     {ok, {ChangeType, Target, Options}};
 decode(?OP_AUTH_SUCCESS, _) ->
     {ok, undefined}.
+
+maybe_decompress(Flags, Body) when Flags band 16#01 =:= 16#01 ->
+    {ok, Body2} = marina_utils:unpack(Body),
+    Body2;
+maybe_decompress(_Flags, Body) ->
+    Body.
+
+skip_tracing(Flags, <<_Uuid:16/binary, Rest/binary>>)
+  when Flags band 16#02 =:= 16#02 ->
+    Rest;
+skip_tracing(_Flags, Body) ->
+    Body.
+
+skip_custom_payload(Flags, <<N:16/unsigned, Rest/binary>>)
+  when Flags band 16#04 =:= 16#04 ->
+    skip_bytes_map(N, Rest);
+skip_custom_payload(_Flags, Body) ->
+    Body.
+
+skip_bytes_map(0, Body) ->
+    Body;
+skip_bytes_map(N, <<KLen:16/unsigned, _Key:KLen/binary,
+                    VLen:32/signed, VBody/binary>>) when VLen >= 0 ->
+    <<_Val:VLen/binary, Rest/binary>> = VBody,
+    skip_bytes_map(N - 1, Rest);
+skip_bytes_map(N, <<KLen:16/unsigned, _Key:KLen/binary,
+                    _VLen:32/signed, Rest/binary>>) ->
+    skip_bytes_map(N - 1, Rest).
+
+skip_warnings(Flags, <<N:16/unsigned, Rest/binary>>)
+  when Flags band 16#08 =:= 16#08 ->
+    skip_string_list(N, Rest);
+skip_warnings(_Flags, Body) ->
+    Body.
+
+skip_string_list(0, Body) ->
+    Body;
+skip_string_list(N, <<Len:16/unsigned, _S:Len/binary, Rest/binary>>) ->
+    skip_string_list(N - 1, Rest).
 
 decode_columns(Bin, Count) ->
     decode_columns(Bin, Count, []).

--- a/src/marina_body.erl
+++ b/src/marina_body.erl
@@ -247,10 +247,16 @@ decode_type(<<16#F:16, Rest/binary>>) ->
     {timeuuid, Rest};
 decode_type(<<16#10:16, Rest/binary>>) ->
     {inet, Rest};
+decode_type(<<16#11:16, Rest/binary>>) ->
+    {date, Rest};
+decode_type(<<16#12:16, Rest/binary>>) ->
+    {time, Rest};
 decode_type(<<16#13:16, Rest/binary>>) ->
     {smallint, Rest};
 decode_type(<<16#14:16, Rest/binary>>) ->
     {tinyint, Rest};
+decode_type(<<16#15:16, Rest/binary>>) ->
+    {duration, Rest};
 decode_type(<<16#20:16, Rest/binary>>) ->
     {Type, Rest2} = decode_type(Rest),
     {{list, Type}, Rest2};


### PR DESCRIPTION
## Summary

Moves the wire handshake from CQL v3 to v4. Three atomic commits:

**1. Treat response frame flags as a bitmask.** `marina_body:decode/1` pattern-matched the flags byte as `0 | 1`, which crashed with `function_clause` on any other bit combination. Per the CQL spec, flags carries up to four bits in parallel (0x01 compression, 0x02 tracing, 0x04 custom_payload, 0x08 warnings) and the body is the concatenation of each enabled preamble in spec order followed by the opcode-specific payload. A server sending warnings (which Scylla can do unprompted under v4) would have hit the crash today. Rewritten to strip the four preambles in order. Widens `#frame.flags` from `0 | 1` to `byte()` to reflect what the response path actually carries — dialyzer flagged the bitwise-and tests as unreachable under the narrow type.

**2. Add v4 type decoders: date (0x11), time (0x12), duration (0x15).** marina already handled the other two v4-only codes (smallint 0x13, tinyint 0x14) despite nominally being a v3 client, so the gap was just these three. Same convention as every other type: atom tag in column metadata, raw bytes in row values for the caller to parse.

**3. Bump `?PROTO_VERSION` to 4.** Frame layout is bit-for-bit compatible with v3 so `marina_frame.erl` needs no change. The one substantive decode delta on the response side is PREPARED result kind: v4 adds a `pk_count` + `pk_indexes` preamble before the normal metadata. Split the shared decoder into `decode_prepared_metadata/1` (skips the pk info) and `decode_result_metadata/1` (unchanged, used for ROWS).

Scylla caps at v4 server-side (verified), so this is the realistic ceiling. No v5 work here.

`make xref`, `make dialyzer`, `make eunit` all green against Scylla 6.2.3 (14/14).