### PR TITLE
Fix CI image: ship matching libssl with the Erlang install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,15 @@ RUN apt-get update && apt-get -y --no-install-recommends install \
   && rm -rf /var/lib/apt/lists/*
 
 ENV PATH="/usr/local/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/opt/erlang-libs"
+
+# Erlang 28.3.1 is built on Debian trixie (OpenSSL 3.4); Scylla 6.2.3 is
+# Ubuntu 24.04 noble (OpenSSL 3.0). Shipping the trixie libssl alongside
+# the Erlang install lets crypto.so resolve its OPENSSL_3.4.0 symbol version
+# without overwriting the Ubuntu system libs that Scylla itself links
+# against.
+COPY --from=erlang:28.3.1 /usr/lib/x86_64-linux-gnu/libssl.so.3 /opt/erlang-libs/
+COPY --from=erlang:28.3.1 /usr/lib/x86_64-linux-gnu/libcrypto.so.3 /opt/erlang-libs/
 
 COPY --from=erlang:28.3.1 /usr/local/lib/erlang /usr/local/lib/erlang
 COPY --from=erlang:28.3.1 /usr/local/bin/ct_run /usr/local/bin/


### PR DESCRIPTION
## Summary

The CI image's `make compile` step was failing with:

\`\`\`
Failed to load NIF library: '/usr/lib/x86_64-linux-gnu/libcrypto.so.3:
version \`OPENSSL_3.4.0' not found (required by
/usr/local/lib/erlang/lib/crypto-5.8/priv/lib/crypto.so)'
\`\`\`

Root cause is a distro mismatch between the Dockerfile's two base layers: \`erlang:28.3.1\` is Debian trixie (OpenSSL 3.4.x) and \`scylladb/scylla:6.2.3\` is Ubuntu 24.04 noble (OpenSSL 3.0.x). Copying the Erlang runtime into the Scylla image leaves \`crypto.so\` dlopen'ing Ubuntu's libcrypto, which doesn't carry the \`OPENSSL_3.4.0\` symbol version.

Fix is self-contained: also copy \`libssl.so.3\` and \`libcrypto.so.3\` from the Erlang image into `/opt/erlang-libs/` (a path Scylla doesn't touch) and point `LD_LIBRARY_PATH` there. Erlang's NIF dlopen now resolves its own matching libs; Scylla continues to use the system libs it was built against. Verified with \`ldd\` on the built image: \`crypto.so\` correctly resolves \`libcrypto.so.3 → /opt/erlang-libs/libcrypto.so.3\`.

After merging, re-run the \`Build and push CI base image\` workflow to publish the corrected image.