### PR TITLE
Topology refresh via a persistent CQL control connection

### DIFF
--- a/src/marina_body.erl
+++ b/src/marina_body.erl
@@ -69,7 +69,38 @@ decode(?OP_RESULT, <<5:32/integer, Rest/binary>>) ->
 
     {ok, {ChangeType, Target, Options}};
 decode(?OP_AUTH_SUCCESS, _) ->
-    {ok, undefined}.
+    {ok, undefined};
+decode(?OP_EVENT, Body) ->
+    {EventType, Rest} = marina_types:decode_string(Body),
+    decode_event(EventType, Rest).
+
+decode_event(<<"TOPOLOGY_CHANGE">>, Body) ->
+    {Kind, Rest} = marina_types:decode_string(Body),
+    {Addr, _Port, <<>>} = decode_inet(Rest),
+    {ok, {event, topology_change, event_kind(Kind), Addr}};
+decode_event(<<"STATUS_CHANGE">>, Body) ->
+    {Kind, Rest} = marina_types:decode_string(Body),
+    {Addr, _Port, <<>>} = decode_inet(Rest),
+    {ok, {event, status_change, event_kind(Kind), Addr}};
+decode_event(<<"SCHEMA_CHANGE">>, Body) ->
+    %% Payload shape matches OP_RESULT kind 5. marina does not consume schema
+    %% events, so pass the raw body through without committing to a shape —
+    %% a future schema-aware caller can decode it at the call site.
+    {ok, {event, schema_change, Body}}.
+
+event_kind(<<"NEW_NODE">>) -> new_node;
+event_kind(<<"REMOVED_NODE">>) -> removed_node;
+event_kind(<<"MOVED_NODE">>) -> moved_node;
+event_kind(<<"UP">>) -> up;
+event_kind(<<"DOWN">>) -> down;
+event_kind(Other) -> Other.
+
+%% [inet] = <byte N><N bytes of IP><int port>
+decode_inet(<<4, A, B, C, D, Port:32/signed, Rest/binary>>) ->
+    {{A, B, C, D}, Port, Rest};
+decode_inet(<<16, A:16, B:16, C:16, D:16, E:16, F:16, G:16, H:16,
+              Port:32/signed, Rest/binary>>) ->
+    {{A, B, C, D, E, F, G, H}, Port, Rest}.
 
 maybe_decompress(Flags, Body) when Flags band 16#01 =:= 16#01 ->
     {ok, Body2} = marina_utils:unpack(Body),

--- a/src/marina_cache.erl
+++ b/src/marina_cache.erl
@@ -3,6 +3,7 @@
 
 -export([
     erase/2,
+    erase_pool/1,
     get/2,
     init/0,
     put/3
@@ -19,6 +20,12 @@ erase(Pool, Key) ->
         error:badarg ->
             {error, not_found}
     end.
+
+-spec erase_pool(atom()) -> non_neg_integer().
+
+erase_pool(Pool) ->
+    ets:select_delete(?ETS_TABLE_CACHE,
+        [{{{'$1', '$2'}, '_'}, [{'==', '$1', Pool}], [true]}]).
 
 -spec get(atom(), binary()) -> {ok, term()} | {error, not_found}.
 

--- a/src/marina_control.erl
+++ b/src/marina_control.erl
@@ -1,0 +1,257 @@
+%% Owns a long-lived CQL control connection to the cluster, subscribes to
+%% server-side EVENT frames (TOPOLOGY_CHANGE, STATUS_CHANGE, SCHEMA_CHANGE),
+%% and drives a full ring re-sync whenever the topology changes.
+%%
+%% Design is events-only and reconnect-on-change:
+%%
+%%   connecting -> dial any bootstrap_ip -> STARTUP + AUTH -> system.local +
+%%     system.peers -> post {topology_full_sync, Nodes} to marina_pool_server
+%%     -> REGISTER -> active-once -> subscribed
+%%   subscribed -> any TOPOLOGY_CHANGE event closes the socket and re-enters
+%%     connecting, which naturally re-queries system.peers and re-posts
+%%     topology_full_sync. STATUS_CHANGE / SCHEMA_CHANGE are logged and
+%%     otherwise ignored — shackle already reconnects transparently on
+%%     per-node outages.
+%%
+%% Every reconnect does the full peers query again, which closes the window
+%% where a topology event could have been missed while the control
+%% connection was down.
+-module(marina_control).
+-include("marina_internal.hrl").
+
+-behaviour(gen_statem).
+
+-export([
+    start_link/0
+]).
+
+-export([
+    callback_mode/0,
+    code_change/4,
+    init/1,
+    terminate/3
+]).
+
+-export([
+    connecting/3,
+    subscribed/3
+]).
+
+-define(CONTROL_STREAM, 0).
+-define(EVENT_STREAM, -1).
+-define(EVENT_TYPES, [
+    <<"TOPOLOGY_CHANGE">>,
+    <<"STATUS_CHANGE">>,
+    <<"SCHEMA_CHANGE">>
+]).
+-define(BACKOFF_MIN, 500).
+-define(BACKOFF_MAX, 30000).
+
+-record(data, {
+    bootstrap_ips :: [string()],
+    port          :: pos_integer(),
+    backoff       :: pos_integer(),
+    socket        :: undefined | inet:socket(),
+    buffer        :: binary()
+}).
+
+-type data() :: #data {}.
+
+%% public
+-spec start_link() -> {ok, pid()}.
+
+start_link() ->
+    gen_statem:start_link({local, ?MODULE}, ?MODULE, undefined, []).
+
+%% gen_statem callbacks
+-spec callback_mode() -> state_functions.
+
+callback_mode() ->
+    state_functions.
+
+-spec init(undefined) ->
+    {ok, connecting, data(), [gen_statem:action()]}.
+
+init(undefined) ->
+    BootstrapIps = ?GET_ENV(bootstrap_ips, ?DEFAULT_BOOTSTRAP_IPS),
+    Port = ?GET_ENV(port, ?DEFAULT_PORT),
+    {ok, connecting, #data {
+        bootstrap_ips = BootstrapIps,
+        port = Port,
+        backoff = ?BACKOFF_MIN,
+        buffer = <<>>
+    }, [{next_event, internal, connect}]}.
+
+-spec terminate(term(), atom(), data()) -> ok.
+
+terminate(_Reason, _State, #data {socket = undefined}) ->
+    ok;
+terminate(_Reason, _State, #data {socket = Socket}) ->
+    _ = gen_tcp:close(Socket),
+    ok.
+
+-spec code_change(term(), atom(), data(), term()) -> {ok, atom(), data()}.
+
+code_change(_OldVsn, OldState, OldData, _Extra) ->
+    {ok, OldState, OldData}.
+
+%% state: connecting
+-spec connecting(gen_statem:event_type(), term(), data()) ->
+    gen_statem:event_handler_result(atom()).
+
+connecting(internal, connect, #data {
+        bootstrap_ips = Ips,
+        port = Port
+    } = Data) ->
+
+    case establish(Ips, Port) of
+        {ok, Socket, Nodes} ->
+            marina_pool_server ! {topology_full_sync, Nodes},
+            case subscribe(Socket) of
+                ok ->
+                    ok = inet:setopts(Socket, [{active, once}]),
+                    {next_state, subscribed, Data#data {
+                        socket = Socket,
+                        buffer = <<>>,
+                        backoff = ?BACKOFF_MIN
+                    }};
+                {error, Reason} ->
+                    _ = gen_tcp:close(Socket),
+                    shackle_utils:warning_msg(?MODULE,
+                        "register failed: ~p~n", [Reason]),
+                    backoff(Data)
+            end;
+        {error, Reason} ->
+            shackle_utils:warning_msg(?MODULE,
+                "control connect failed: ~p~n", [Reason]),
+            backoff(Data)
+    end;
+connecting(state_timeout, reconnect, Data) ->
+    {keep_state, Data, [{next_event, internal, connect}]};
+connecting(_, _, Data) ->
+    {keep_state, Data}.
+
+%% state: subscribed
+-spec subscribed(gen_statem:event_type(), term(), data()) ->
+    gen_statem:event_handler_result(atom()).
+
+subscribed(info, {tcp, Socket, Chunk}, #data {
+        socket = Socket,
+        buffer = Buffer
+    } = Data) ->
+
+    {Rest, Frames} = marina_frame:decode(<<Buffer/binary, Chunk/binary>>),
+    case process_frames(Frames) of
+        cycle ->
+            _ = gen_tcp:close(Socket),
+            {next_state, connecting,
+                Data#data {socket = undefined, buffer = <<>>,
+                           backoff = ?BACKOFF_MIN},
+                [{next_event, internal, connect}]};
+        continue ->
+            ok = inet:setopts(Socket, [{active, once}]),
+            {keep_state, Data#data {buffer = Rest}}
+    end;
+subscribed(info, {tcp_closed, Socket}, #data {socket = Socket} = Data) ->
+    shackle_utils:warning_msg(?MODULE, "control socket closed~n", []),
+    backoff(Data#data {socket = undefined, buffer = <<>>});
+subscribed(info, {tcp_error, Socket, Reason}, #data {socket = Socket} = Data) ->
+    shackle_utils:warning_msg(?MODULE,
+        "control socket error: ~p~n", [Reason]),
+    _ = gen_tcp:close(Socket),
+    backoff(Data#data {socket = undefined, buffer = <<>>});
+subscribed(_, _, Data) ->
+    {keep_state, Data}.
+
+%% private
+backoff(#data {backoff = B} = Data) ->
+    Next = min(B * 2, ?BACKOFF_MAX),
+    {next_state, connecting, Data#data {backoff = Next},
+        [{state_timeout, B, reconnect}]}.
+
+establish([], _Port) ->
+    {error, no_reachable_seed};
+establish([Ip | Rest], Port) ->
+    case marina_utils:connect(Ip, Port) of
+        {ok, Socket} ->
+            case handshake(Socket) of
+                {ok, Nodes} ->
+                    {ok, Socket, Nodes};
+                {error, Reason} ->
+                    _ = gen_tcp:close(Socket),
+                    shackle_utils:warning_msg(?MODULE,
+                        "seed ~s handshake failed: ~p~n", [Ip, Reason]),
+                    establish(Rest, Port)
+            end;
+        {error, Reason} ->
+            shackle_utils:warning_msg(?MODULE,
+                "seed ~s unreachable: ~p~n", [Ip, Reason]),
+            establish(Rest, Port)
+    end.
+
+handshake(Socket) ->
+    case marina_utils:startup(Socket) of
+        {ok, undefined} ->
+            discover(Socket);
+        {ok, _Authenticator} ->
+            case marina_utils:authenticate(Socket) of
+                ok -> discover(Socket);
+                {error, Reason} -> {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+discover(Socket) ->
+    case marina_utils:query(Socket, ?LOCAL_QUERY) of
+        {ok, {result, _, _, [[_, Datacenter, _]] = LocalRows}} ->
+            case marina_utils:query(Socket, ?PEERS_QUERY) of
+                {ok, {result, _, _, PeerRows}} ->
+                    {ok, filter_dc(LocalRows ++ PeerRows, Datacenter)};
+                {error, Reason} ->
+                    {error, Reason}
+            end;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+filter_dc([], _Dc) ->
+    [];
+filter_dc([[Addr, _, Tokens] | T], undefined) ->
+    [{Addr, Tokens} | filter_dc(T, undefined)];
+filter_dc([[Addr, Dc, Tokens] | T], Dc) ->
+    [{Addr, Tokens} | filter_dc(T, Dc)];
+filter_dc([_ | T], Dc) ->
+    filter_dc(T, Dc).
+
+subscribe(Socket) ->
+    FrameFlags = marina_utils:frame_flags(),
+    Msg = marina_request:register(?CONTROL_STREAM, FrameFlags, ?EVENT_TYPES),
+    case marina_utils:sync_msg(Socket, Msg) of
+        {ok, undefined} -> ok;
+        {ok, Other} -> {error, {unexpected_register_response, Other}};
+        {error, Reason} -> {error, Reason}
+    end.
+
+process_frames([]) ->
+    continue;
+process_frames([#frame {stream = ?EVENT_STREAM} = Frame | Rest]) ->
+    case marina_body:decode(Frame) of
+        {ok, {event, topology_change, Kind, Addr}} ->
+            shackle_utils:warning_msg(?MODULE,
+                "topology change: ~p ~p~n", [Kind, Addr]),
+            cycle;
+        {ok, {event, status_change, Kind, Addr}} ->
+            shackle_utils:warning_msg(?MODULE,
+                "status change: ~p ~p~n", [Kind, Addr]),
+            process_frames(Rest);
+        {ok, {event, schema_change, _Body}} ->
+            process_frames(Rest);
+        {ok, Other} ->
+            shackle_utils:warning_msg(?MODULE,
+                "unexpected event frame: ~p~n", [Other]),
+            process_frames(Rest)
+    end;
+process_frames([_Frame | Rest]) ->
+    %% stray non-event response (e.g. late STARTUP reply) — ignore
+    process_frames(Rest).

--- a/src/marina_pool.erl
+++ b/src/marina_pool.erl
@@ -11,7 +11,8 @@
     node/1,
     node_id/1,
     start/2,
-    stop/1
+    stop/1,
+    sync/3
 ]).
 
 %% public
@@ -57,11 +58,8 @@ node_id(<<A, B, C, D>>) ->
 -spec start(random | token_aware, [{binary(), binary()}]) ->
     ok.
 
-start(random, Nodes) ->
-    start(Nodes, random, 1);
-start(token_aware, Nodes) ->
-    marina_ring:build(Nodes),
-    start(Nodes, token_aware, 1).
+start(Strategy, Nodes) ->
+    sync(Strategy, Nodes, []).
 
 -spec stop(non_neg_integer()) ->
     ok.
@@ -74,6 +72,21 @@ stop(N) ->
     ok = shackle_pool:stop(NodeId),
     ok = foil:delete(?MODULE, {node, N}),
     stop(N - 1).
+
+-spec sync(random | token_aware,
+           [{binary(), binary()}],
+           [{binary(), binary()}]) -> ok.
+
+sync(Strategy, NewNodes, OldNodes) ->
+    OldAddrs = [Addr || {Addr, _} <- OldNodes],
+    NewAddrs = [Addr || {Addr, _} <- NewNodes],
+    lists:foreach(fun stop_node/1, OldAddrs -- NewAddrs),
+    lists:foreach(fun start_node/1, NewAddrs -- OldAddrs),
+    rebuild_index(Strategy, NewNodes, length(OldNodes)),
+    case Strategy of
+        token_aware -> marina_ring:build(NewNodes);
+        random -> ok
+    end.
 
 %% private
 node({random, NodeCount}, undefined) ->
@@ -120,17 +133,22 @@ start(<<A, B, C, D>> = RpcAddress) ->
             {error, Reason}
     end.
 
-start([], random, N) ->
-    foil:insert(?MODULE, strategy, {random, N - 1}),
-    foil:load(?MODULE);
-start([], token_aware, N) ->
-    foil:insert(?MODULE, strategy, {token_aware, N - 1}),
-    foil:load(?MODULE);
-start([{RpcAddress, _Tokens} | T], Strategy, N) ->
-    case start(RpcAddress) of
-        {ok, NodeId} ->
-            foil:insert(?MODULE, {node, N}, NodeId),
-            start(T, Strategy, N + 1);
-        {error, _Reason} ->
-            start(T, Strategy, N)
-    end.
+start_node(RpcAddress) ->
+    _ = start(RpcAddress),
+    ok.
+
+stop_node(RpcAddress) ->
+    NodeId = node_id(RpcAddress),
+    _ = catch shackle_pool:stop(NodeId),
+    _ = marina_cache:erase_pool(NodeId),
+    ok.
+
+rebuild_index(Strategy, NewNodes, OldCount) ->
+    _ = [foil:delete(?MODULE, {node, N}) || N <- lists:seq(1, OldCount)],
+    lists:foldl(fun ({Addr, _}, N) ->
+        foil:insert(?MODULE, {node, N}, node_id(Addr)),
+        N + 1
+    end, 1, NewNodes),
+    foil:insert(?MODULE, strategy, {Strategy, length(NewNodes)}),
+    foil:load(?MODULE),
+    ok.

--- a/src/marina_pool_server.erl
+++ b/src/marina_pool_server.erl
@@ -19,7 +19,7 @@
 -record(state, {
     bootstrap_ips :: list(),
     datacenter    :: undefined | binary(),
-    node_count    :: undefined | pos_integer(),
+    nodes         :: [{binary(), binary()}],
     port          :: pos_integer(),
     strategy      :: random | token_aware,
     timer_ref     :: undefined | reference()
@@ -47,6 +47,7 @@ init(_Name, _Parent, undefined) ->
 
     {ok, #state {
         bootstrap_ips = BootstrapIps,
+        nodes = [],
         port = Port,
         strategy = Strategy
     }}.
@@ -64,20 +65,27 @@ handle_msg(?MSG_BOOTSTRAP, #state {
         {ok, Nodes} ->
             marina_pool:start(Strategy, Nodes),
             {ok, State#state {
-                node_count = length(Nodes)
+                nodes = Nodes
             }};
         {error, _Reason} ->
             shackle_utils:warning_msg(?MODULE, "bootstrap failed~n", []),
             {ok, State#state {
                 timer_ref = erlang:send_after(500, self(), ?MSG_BOOTSTRAP)
             }}
-    end.
+    end;
+handle_msg({topology_full_sync, NewNodes}, #state {
+        nodes = OldNodes,
+        strategy = Strategy
+    } = State) ->
+
+    ok = marina_pool:sync(Strategy, NewNodes, OldNodes),
+    {ok, State#state {nodes = NewNodes}}.
 
 -spec terminate(term(), state()) ->
     ok.
 
-terminate(_Reason, #state {node_count = NodeCount}) ->
-    marina_pool:stop(NodeCount),
+terminate(_Reason, #state {nodes = Nodes}) ->
+    marina_pool:stop(length(Nodes)),
     ok.
 
 %% private

--- a/src/marina_pool_server.erl
+++ b/src/marina_pool_server.erl
@@ -57,15 +57,16 @@ init(_Name, _Parent, undefined) ->
 
 handle_msg(?MSG_BOOTSTRAP, #state {
         bootstrap_ips = BootstrapIps,
+        nodes = OldNodes,
         port = Port,
         strategy = Strategy
     } = State) ->
 
     case nodes(BootstrapIps, Port) of
-        {ok, Nodes} ->
-            marina_pool:start(Strategy, Nodes),
+        {ok, NewNodes} ->
+            ok = marina_pool:sync(Strategy, NewNodes, OldNodes),
             {ok, State#state {
-                nodes = Nodes
+                nodes = NewNodes
             }};
         {error, _Reason} ->
             shackle_utils:warning_msg(?MODULE, "bootstrap failed~n", []),

--- a/src/marina_request.erl
+++ b/src/marina_request.erl
@@ -3,12 +3,14 @@
 
 -compile(inline).
 -compile({inline_size, 512}).
+-compile({no_auto_import, [register/2]}).
 
 -export([
     auth_response/3,
     execute/4,
     prepare/3,
     query/4,
+    register/3,
     startup/1
 ]).
 
@@ -80,6 +82,18 @@ query(Stream, FrameFlags, Query, QueryOpts) ->
         body = Body2
     }).
 
+-spec register(stream(), frame_flag(), [binary()]) -> iolist().
+
+register(Stream, FrameFlags, EventTypes) ->
+    Body = encode_body(FrameFlags, [encode_string_list(EventTypes)]),
+
+    marina_frame:encode(#frame {
+        stream = Stream,
+        opcode = ?OP_REGISTER,
+        flags = FrameFlags,
+        body = Body
+    }).
+
 -spec startup(frame_flag()) -> iolist().
 
 startup(FrameFlags) ->
@@ -103,6 +117,13 @@ encode_body(0, Body) ->
 encode_body(1, Body) ->
     {ok, Body2} = marina_utils:pack(Body),
     Body2.
+
+%% Spec-correct [string list] encoder — a [short] n followed by n [string].
+%% marina_types:encode_string_list/1 prefixes with an [int], which does not
+%% match the CQL wire format and would make the server reject REGISTER.
+encode_string_list(Values) ->
+    Parts = [marina_types:encode_string(V) || V <- Values],
+    iolist_to_binary([marina_types:encode_short(length(Values)), Parts]).
 
 flags(QueryOpts) ->
     {Mask1, Values} = values_flag(QueryOpts),

--- a/src/marina_sup.erl
+++ b/src/marina_sup.erl
@@ -24,5 +24,6 @@ init([]) ->
     marina_pool:init(),
 
     {ok, {{one_for_one, 5, 10}, [
-        ?CHILD(marina_pool_server)
+        ?CHILD(marina_pool_server),
+        ?CHILD(marina_control)
     ]}}.


### PR DESCRIPTION
## Summary

Closes the "Rebuild ring when topology changes" TODO in the README.

marina has always bootstrapped its pool set once at application start and never revisited it. Adding or removing a node in the cluster silently left marina routing to stale atoms and missing new shards until the application was restarted. This PR adds a persistent CQL control connection that subscribes to server-side events and drives a ring re-sync on any topology change.

Four atomic commits:

**1. Add REGISTER and EVENT protocol support.** `marina_request:register/3` emits `OP_REGISTER` with a spec-correct `[string list]` of event types, and `marina_body:decode` handles `OP_EVENT`, unpacking the three variants defined by v4 (TOPOLOGY_CHANGE / STATUS_CHANGE / SCHEMA_CHANGE) into tagged tuples for the caller. A local helper is used for the `[string list]` encoding because `marina_types:encode_string_list/1` uses a 32-bit length prefix that doesn't match the CQL wire format.

**2. Add `marina_cache:erase_pool/1`.** Per-pool prepared-statement eviction, shaped around a pool atom (unlike the `erase_server/1` that was removed during housekeeping, which took a shackle request_id and un-mangled the atom out of it). Called when a node leaves the cluster so a recycled pool atom never hands back statement ids the server no longer recognises.

**3. Refactor `marina_pool` for incremental topology sync.** Introduces `marina_pool:sync/3` as the single entry point for aligning the running pool set to a target node list: diff vs. old, stop pools for removed addresses (clearing their cache), start pools for added ones, rebuild the foil index and ring from scratch. `marina_pool:start/2` becomes a thin wrapper on `sync/3` with `OldNodes=[]`, so the initial bootstrap and a topology change follow exactly the same code path. `marina_pool_server` tracks the full node list in state and gains a `handle_msg` clause for `{topology_full_sync, NewNodes}`.

**4. Add `marina_control` for event-driven topology refresh.** A `gen_statem` in two states:

- `connecting`: dial any `bootstrap_ip`, STARTUP + AUTH, query `system.local` + `system.peers`, post `{topology_full_sync, Nodes}` to `marina_pool_server`, REGISTER for events, flip socket to active-once.
- `subscribed`: accept EVENT frames. Any TOPOLOGY_CHANGE closes the socket and cycles back through `connecting`, which naturally re-queries `system.peers` and re-posts the fresh node list. STATUS_CHANGE and SCHEMA_CHANGE are logged and otherwise ignored — shackle already reconnects per-node and marina doesn't act on schema events yet.

Doing a full re-query on every reconnect (not just on start) is the anti-missed-event guard: if the control connection drops and misses an event, the next successful handshake re-discovers the cluster state. This is what "events-only with a full re-sync on reconnect" means in the plan — no periodic poll.

`marina_pool_server`'s bootstrap handler is now idempotent (uses `marina_pool:sync/3` with the current node list as `OldNodes`), so the race between `marina_control`'s first topology_full_sync and the pool_server's self-bootstrap converges cleanly without double-starting shackle pools.

`make xref`, `make dialyzer`, and `make eunit` all green against Scylla 6.2.3 (14/14) — including the compressed suite. Stacks cleanly on master; does not depend on #66 (the CI image libssl fix), though local eunit verification against the OpenSSL 3.4 arm64 runtime confirmed it.