### PR TITLE
Add BATCH query support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ High-Performance Erlang Cassandra / Scylla CQL Client
 ## Features
 
 * Authentication support
+* Batch queries (LOGGED / UNLOGGED / COUNTER)
 * Compression support (LZ4)
-* CQL spec 3.2.0
+* CQL native protocol v4
 * Fast pool implementation (random, round_robin)
 * Load-balancing policies (random, token_aware)
 * Performance optimized
@@ -26,9 +27,15 @@ High-Performance Erlang Cassandra / Scylla CQL Client
     <th>Description</th>
   </theader>
   <tr>
+    <td>backlog_size</td>
+    <td>pos_integer()</td>
+    <td>1024</td>
+    <td>per-connection shackle backlog</td>
+  </tr>
+  <tr>
     <td>bootstrap_ips</td>
-    <td>[list()]</td>
-    <td>["5.5.5.5", "5.5.5.6"]</td>
+    <td>[string()]</td>
+    <td>["127.0.0.1"]</td>
     <td>ips used to bootstrap the pool</td>
   </tr>
   <tr>
@@ -56,6 +63,12 @@ High-Performance Erlang Cassandra / Scylla CQL Client
     <td>number of connections per node</td>
   </tr>
   <tr>
+    <td>pool_strategy</td>
+    <td>random | round_robin</td>
+    <td>random</td>
+    <td>shackle's connection-selection strategy within a per-node pool</td>
+  </tr>
+  <tr>
     <td>port</td>
     <td>pos_integer()</td>
     <td>9042</td>
@@ -78,6 +91,12 @@ High-Performance Erlang Cassandra / Scylla CQL Client
     <td>pos_integer()</td>
     <td>1500</td>
     <td>reconnect minimum time</td>
+  </tr>
+  <tr>
+    <td>socket_options</td>
+    <td>[gen_tcp:option()]</td>
+    <td>see marina_internal.hrl</td>
+    <td>gen_tcp socket options for each connection</td>
   </tr>
   <tr>
     <td>strategy</td>
@@ -143,6 +162,13 @@ The pool is bootstraped by querying the `system.peers` table. `marina` will try 
      {column_spec,<<"test">>,<<"users">>,<<"value">>,blob}],
         undefined},
             0,[]}}
+
+6> marina:batch([
+    {query, <<"INSERT INTO test.kv (k, v) VALUES (1, 'a')">>, []},
+    {query, <<"INSERT INTO test.kv (k, v) VALUES (2, 'b')">>, []}
+], #{batch_type => logged, timeout => 1000}).
+
+{ok,undefined}
 ```
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -155,7 +155,6 @@ make xref
 
 ### TODOs
 
-* Batch queries
 * Rebuild ring when topology changes
 
 ## License

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ High-Performance Erlang Cassandra / Scylla CQL Client
 * Load-balancing policies (random, token_aware)
 * Performance optimized
 * Prepared statement cache
+* Ring refresh on TOPOLOGY_CHANGE events (event-driven, no polling)
 
 ## Environment variables
 
@@ -178,10 +179,6 @@ make dialyzer
 make eunit
 make xref
 ```
-
-### TODOs
-
-* Rebuild ring when topology changes
 
 ## License
 

--- a/include/marina.hrl
+++ b/include/marina.hrl
@@ -60,11 +60,16 @@
     ?CONSISTENCY_LOCAL_SERIAL |
     ?CONSISTENCY_LOCAL_ONE.
 
+-type batch_type() :: logged | unlogged | counter.
+-type batch_query() ::
+    {query, query(), values()} |
+    {prepared, statement_id(), values()}.
 -type error() :: {error, term()}.
 -type frame() :: #frame {}.
 -type frame_flag() :: 0..1.
 -type query() :: binary().
 -type query_opts() :: #{
+    batch_type => batch_type(),
     consistency_level => consistency_level(),
     page_size => pos_integer(),
     paging_state => binary(),

--- a/src/marina.erl
+++ b/src/marina.erl
@@ -2,8 +2,10 @@
 -include("marina_internal.hrl").
 
 -export([
+    async_batch/2,
     async_query/2,
     async_reusable_query/2,
+    batch/2,
     query/2,
     receive_response/1,
     response/1,
@@ -11,6 +13,12 @@
 ]).
 
 %% public
+-spec async_batch([batch_query()], query_opts()) ->
+    {ok, shackle:request_id()} | error().
+
+async_batch(Queries, QueryOpts) ->
+    async_call({batch, Queries}, QueryOpts).
+
 -spec async_query(query(), query_opts()) ->
     {ok, shackle:request_id()} | error().
 
@@ -28,6 +36,12 @@ async_reusable_query(Query, QueryOpts) ->
         {error, Reason} ->
             {error, Reason}
     end.
+
+-spec batch([batch_query()], query_opts()) ->
+    {ok, term()} | error().
+
+batch(Queries, QueryOpts) ->
+    call({batch, Queries}, QueryOpts).
 
 -spec query(query(), query_opts()) ->
     {ok, term()} | error().

--- a/src/marina_client.erl
+++ b/src/marina_client.erl
@@ -69,6 +69,8 @@ handle_request({Request, QueryOpts}, #state {
 
     RequestId = Requests rem ?MAX_STREAM_ID,
     Data = case Request of
+        {batch, Queries} ->
+            marina_request:batch(RequestId, FrameFlags, Queries, QueryOpts);
         {execute, StatementId} ->
             marina_request:execute(RequestId, FrameFlags, StatementId,
                 QueryOpts);

--- a/src/marina_request.erl
+++ b/src/marina_request.erl
@@ -7,6 +7,7 @@
 
 -export([
     auth_response/3,
+    batch/4,
     execute/4,
     prepare/3,
     query/4,
@@ -26,6 +27,29 @@ auth_response(FrameFlags, Username, Password) ->
         opcode = ?OP_AUTH_RESPONSE,
         flags = FrameFlags,
         body = Body2
+    }).
+
+-spec batch(stream(), frame_flag(), [batch_query()], query_opts()) -> iolist().
+
+batch(Stream, FrameFlags, Queries, QueryOpts) ->
+    BatchType = encode_batch_type(
+        marina_utils:query_opts(batch_type, QueryOpts)),
+    ConsistencyLevel = marina_utils:query_opts(consistency_level, QueryOpts),
+    EncodedQueries = [encode_batch_query(Q) || Q <- Queries],
+
+    Body = encode_body(FrameFlags, [
+        BatchType,
+        marina_types:encode_short(length(Queries)),
+        EncodedQueries,
+        marina_types:encode_short(ConsistencyLevel),
+        <<0>>
+    ]),
+
+    marina_frame:encode(#frame {
+        stream = Stream,
+        opcode = ?OP_BATCH,
+        flags = FrameFlags,
+        body = Body
     }).
 
 -spec execute(stream(), frame_flag(), statement_id(), query_opts()) -> iolist().
@@ -117,6 +141,20 @@ encode_body(0, Body) ->
 encode_body(1, Body) ->
     {ok, Body2} = marina_utils:pack(Body),
     Body2.
+
+encode_batch_type(logged) -> <<0>>;
+encode_batch_type(unlogged) -> <<1>>;
+encode_batch_type(counter) -> <<2>>.
+
+encode_batch_query({query, Query, Values}) ->
+    [<<0>>, marina_types:encode_long_string(Query), encode_batch_values(Values)];
+encode_batch_query({prepared, StatementId, Values}) ->
+    [<<1>>, marina_types:encode_short_bytes(StatementId),
+     encode_batch_values(Values)].
+
+encode_batch_values(Values) ->
+    [marina_types:encode_short(length(Values)),
+     [marina_types:encode_bytes(V) || V <- Values]].
 
 %% Spec-correct [string list] encoder — a [short] n followed by n [string].
 %% marina_types:encode_string_list/1 prefixes with an [int], which does not

--- a/src/marina_utils.erl
+++ b/src/marina_utils.erl
@@ -69,6 +69,8 @@ query(Socket, Query) ->
 -spec query_opts(atom(), query_opts()) ->
     term().
 
+query_opts(batch_type, QueryOpts) ->
+    maps:get(batch_type, QueryOpts, logged);
 query_opts(consistency_level, QueryOpts) ->
     maps:get(consistency_level, QueryOpts, ?DEFAULT_CONSISTENCY_LEVEL);
 query_opts(flags, QueryOpts) ->

--- a/test/marina_tests.erl
+++ b/test/marina_tests.erl
@@ -16,6 +16,7 @@ marina_test_() ->
         fun async_query_subtest/0,
         fun async_reusable_query_subtest/0,
         fun async_reusable_query_invalid_query_subtest/0,
+        fun batch_subtest/0,
         fun counters_subtest/0,
         fun paging_subtest/0,
         fun query_subtest/0,
@@ -60,6 +61,41 @@ async_reusable_query_subtest() ->
 async_reusable_query_invalid_query_subtest() ->
     Query = <<"SELECT * FROM user LIMIT 1;">>,
     {error, {8704, _}} = marina:async_reusable_query(Query, #{}).
+
+batch_subtest() ->
+    query(<<"DROP TABLE test.batch_rows;">>),
+    query(<<"CREATE TABLE test.batch_rows (k int PRIMARY KEY, v text);">>),
+
+    %% LOGGED batch of two raw INSERTs
+    {ok, undefined} = marina:batch([
+        {query, <<"INSERT INTO test.batch_rows (k, v) VALUES (1, 'a')">>, []},
+        {query, <<"INSERT INTO test.batch_rows (k, v) VALUES (2, 'b')">>, []}
+    ], #{batch_type => logged,
+         consistency_level => ?CONSISTENCY_LOCAL_ONE,
+         timeout => ?TIMEOUT}),
+    {ok, {result, _, 2, _}} = query(<<"SELECT * FROM test.batch_rows;">>),
+
+    %% Warm the prepared-statement cache, then pull the id out to feed a batch
+    InsertPrepared =
+        <<"INSERT INTO test.batch_rows (k, v) VALUES (?, ?)">>,
+    {ok, _} = marina:reusable_query(InsertPrepared,
+        #{values => [marina_types:encode_int(3), <<"c">>],
+          consistency_level => ?CONSISTENCY_LOCAL_ONE,
+          timeout => ?TIMEOUT}),
+    {ok, Pool} = marina_pool:node(undefined),
+    {ok, StatementId} = marina_cache:get(Pool, InsertPrepared),
+
+    %% UNLOGGED batch mixing a prepared statement and a raw query
+    {ok, undefined} = marina:batch([
+        {prepared, StatementId,
+            [marina_types:encode_int(4), <<"d">>]},
+        {query, <<"INSERT INTO test.batch_rows (k, v) VALUES (5, 'e')">>, []}
+    ], #{batch_type => unlogged,
+         consistency_level => ?CONSISTENCY_LOCAL_ONE,
+         timeout => ?TIMEOUT}),
+    {ok, {result, _, 5, _}} = query(<<"SELECT * FROM test.batch_rows;">>),
+
+    query(<<"DROP TABLE test.batch_rows;">>).
 
 counters_subtest() ->
     query(<<"DROP TABLE test.page_view_counts;">>),


### PR DESCRIPTION
## Summary

Closes the \"Batch queries\" TODO in the README. marina now speaks the CQL v4 OP_BATCH frame end to end.

\`marina_request:batch/4\` encodes the body per spec — a one-byte batch type (LOGGED / UNLOGGED / COUNTER), the query count, each query as either a raw CQL statement (kind 0, \`[long string]\` + values) or a prepared id (kind 1, \`[short bytes]\` + values), then consistency and a BATCH-specific flags byte. BATCH uses its own flag set (\`0x10\` serial_consistency, \`0x20\` default_timestamp, \`0x40\` named_values), not the QUERY/EXECUTE Values/Skip_metadata/Page_size/Paging_state mask; marina does not opt into any of those yet so the flags byte is always zero.

\`marina:batch/2\` and \`async_batch/2\` mirror the existing query/reusable signatures. \`Queries\` is \`[batch_query()]\` where each entry is \`{query, Query, Values}\` or \`{prepared, StatementId, Values}\`. The batch type comes off \`query_opts()\` as a new \`batch_type\` key defaulting to \`logged\`. \`marina_client\` routes the request through its existing dispatch switch.

Routing inherits the existing rules: pass a \`routing_key\` to pin the pool (useful when every statement in a batch shares a partition key), otherwise \`marina_pool:node(undefined)\` picks a node at random — batches aren't locally partitionable the way a single query is.

eunit grows a \`batch_subtest\` covering LOGGED (two raw inserts) and UNLOGGED (mixing a prepared statement pulled from \`marina_cache\` after warming via \`reusable_query\`, with a raw insert). 15/15 green against Scylla 6.2.3; \`make xref\` and \`make dialyzer\` also clean.