### PR TITLE
Rewrite test suite: DRY integration tests + unit coverage

### DIFF
--- a/test/marina_body_tests.erl
+++ b/test/marina_body_tests.erl
@@ -1,0 +1,79 @@
+-module(marina_body_tests).
+
+-include("test.hrl").
+
+topology_change_new_node_test() ->
+    Payload = build_event(<<"TOPOLOGY_CHANGE">>, <<"NEW_NODE">>,
+        {10, 0, 0, 42}, 9042),
+    ?assertEqual(
+        {ok, {event, topology_change, new_node, {10, 0, 0, 42}}},
+        decode_event_frame(Payload)).
+
+topology_change_removed_node_test() ->
+    Payload = build_event(<<"TOPOLOGY_CHANGE">>, <<"REMOVED_NODE">>,
+        {192, 168, 1, 1}, 9042),
+    ?assertEqual(
+        {ok, {event, topology_change, removed_node, {192, 168, 1, 1}}},
+        decode_event_frame(Payload)).
+
+status_change_up_test() ->
+    Payload = build_event(<<"STATUS_CHANGE">>, <<"UP">>, {10, 0, 0, 1}, 9042),
+    ?assertEqual(
+        {ok, {event, status_change, up, {10, 0, 0, 1}}},
+        decode_event_frame(Payload)).
+
+status_change_down_test() ->
+    Payload = build_event(<<"STATUS_CHANGE">>, <<"DOWN">>, {10, 0, 0, 2}, 9042),
+    ?assertEqual(
+        {ok, {event, status_change, down, {10, 0, 0, 2}}},
+        decode_event_frame(Payload)).
+
+unknown_topology_kind_passes_raw_atom_through_test() ->
+    %% Future event kinds (e.g. a hypothetical MOVED_RACK) should not
+    %% crash the decoder; event_kind/1 falls through to return the
+    %% binary.
+    Payload = build_event(<<"TOPOLOGY_CHANGE">>, <<"WEIRD">>, {1,1,1,1}, 9042),
+    ?assertEqual(
+        {ok, {event, topology_change, <<"WEIRD">>, {1, 1, 1, 1}}},
+        decode_event_frame(Payload)).
+
+ipv6_inet_decoded_as_8_tuple_test() ->
+    Body = <<(encode_string(<<"STATUS_CHANGE">>))/binary,
+             (encode_string(<<"UP">>))/binary,
+             16, %% ipv6 marker
+             16#2001:16, 16#0db8:16, 0:16, 0:16,
+             0:16, 0:16, 0:16, 1:16,
+             9042:32/signed>>,
+    ?assertEqual(
+        {ok, {event, status_change, up,
+            {16#2001, 16#0db8, 0, 0, 0, 0, 0, 1}}},
+        marina_body:decode(#frame {
+            flags = 0, stream = -1, opcode = ?OP_EVENT, body = Body
+        })).
+
+schema_change_is_passed_through_raw_test() ->
+    Body = <<(encode_string(<<"SCHEMA_CHANGE">>))/binary,
+             (encode_string(<<"CREATED">>))/binary,
+             (encode_string(<<"KEYSPACE">>))/binary,
+             (encode_string(<<"test2">>))/binary>>,
+    {ok, {event, schema_change, Raw}} = marina_body:decode(#frame {
+        flags = 0, stream = -1, opcode = ?OP_EVENT, body = Body
+    }),
+    %% Raw is everything after the SCHEMA_CHANGE header — shape is
+    %% identical to OP_RESULT kind 5, so the caller can route it through
+    %% that decoder later.
+    ?assertMatch(<<_:16, "CREATED", _:16, "KEYSPACE", _:16, "test2">>, Raw).
+
+%% helpers
+decode_event_frame(Body) ->
+    marina_body:decode(#frame {
+        flags = 0, stream = -1, opcode = ?OP_EVENT, body = Body
+    }).
+
+build_event(EventType, Kind, {A, B, C, D}, Port) ->
+    <<(encode_string(EventType))/binary,
+      (encode_string(Kind))/binary,
+      4, A, B, C, D, Port:32/signed>>.
+
+encode_string(Bin) ->
+    <<(byte_size(Bin)):16/unsigned, Bin/binary>>.

--- a/test/marina_buffer_tests.erl
+++ b/test/marina_buffer_tests.erl
@@ -1,0 +1,56 @@
+-module(marina_buffer_tests).
+
+-include("test.hrl").
+
+new_is_empty_test() ->
+    Buf = marina_buffer:new(),
+    {[], _} = marina_buffer:decode(<<>>, Buf).
+
+single_frame_test() ->
+    Data = response(1, ?OP_READY, <<>>),
+    {[Frame], _} = marina_buffer:decode(Data, marina_buffer:new()),
+    ?assertEqual(1, Frame#frame.stream).
+
+multiple_frames_in_one_chunk_test() ->
+    F1 = response(1, ?OP_READY, <<>>),
+    F2 = response(2, ?OP_READY, <<"ab">>),
+    {Frames, _} = marina_buffer:decode(<<F1/binary, F2/binary>>,
+        marina_buffer:new()),
+    Streams = [F#frame.stream || F <- Frames],
+    ?assertEqual([1, 2], lists:sort(Streams)).
+
+splits_across_chunks_test() ->
+    %% A frame arriving one byte at a time should decode when the last
+    %% byte lands and not before.
+    Frame = response(42, ?OP_READY, <<"hello">>),
+    feed_byte_by_byte(Frame, 42).
+
+splits_before_header_complete_test() ->
+    %% Fewer than 9 bytes is not enough to read the header. Buffer must
+    %% not panic and must emit the frame once the rest arrives.
+    Frame = response(7, ?OP_READY, <<"world">>),
+    H = binary:part(Frame, 0, 5),
+    T = binary:part(Frame, 5, byte_size(Frame) - 5),
+    B0 = marina_buffer:new(),
+    {[], B1} = marina_buffer:decode(H, B0),
+    {[F], _} = marina_buffer:decode(T, B1),
+    ?assertEqual(7, F#frame.stream),
+    ?assertEqual(<<"world">>, F#frame.body).
+
+%% helpers
+response(Stream, Opcode, Body) ->
+    Encoded = iolist_to_binary(marina_frame:encode(#frame {
+        stream = Stream, flags = 0, opcode = Opcode, body = Body
+    })),
+    <<V:8, Rest/binary>> = Encoded,
+    <<(V bor 16#80):8, Rest/binary>>.
+
+feed_byte_by_byte(Binary, ExpectedStream) ->
+    feed_byte_by_byte(Binary, ExpectedStream, marina_buffer:new()).
+
+feed_byte_by_byte(<<Last:8>>, ExpectedStream, Buf) ->
+    {[F], _} = marina_buffer:decode(<<Last>>, Buf),
+    ?assertEqual(ExpectedStream, F#frame.stream);
+feed_byte_by_byte(<<Byte:8, Rest/binary>>, ExpectedStream, Buf) ->
+    {[], Buf2} = marina_buffer:decode(<<Byte>>, Buf),
+    feed_byte_by_byte(Rest, ExpectedStream, Buf2).

--- a/test/marina_cache_tests.erl
+++ b/test/marina_cache_tests.erl
@@ -1,0 +1,49 @@
+-module(marina_cache_tests).
+
+-include("test.hrl").
+
+marina_cache_test_() ->
+    {setup,
+        fun () -> marina_cache:init(), ok end,
+        fun (_) -> ets:delete(?ETS_TABLE_CACHE) end,
+        [fun put_then_get/0,
+         fun get_missing_is_not_found/0,
+         fun erase_removes_single_entry/0,
+         fun erase_missing_is_not_found/0,
+         fun erase_pool_removes_all_for_pool/0,
+         fun erase_pool_leaves_other_pools_alone/0]}.
+
+put_then_get() ->
+    ok = marina_cache:put(pool_a, <<"q1">>, <<"id1">>),
+    ?assertEqual({ok, <<"id1">>}, marina_cache:get(pool_a, <<"q1">>)).
+
+get_missing_is_not_found() ->
+    ?assertEqual({error, not_found}, marina_cache:get(pool_a, <<"nope">>)).
+
+erase_removes_single_entry() ->
+    ok = marina_cache:put(pool_a, <<"q2">>, <<"id2">>),
+    ok = marina_cache:erase(pool_a, <<"q2">>),
+    ?assertEqual({error, not_found}, marina_cache:get(pool_a, <<"q2">>)).
+
+erase_missing_is_not_found() ->
+    %% Deleting a non-existent entry returns ok from ETS (idempotent),
+    %% not {error, not_found}. erase_server/1 was called on every socket
+    %% close during the dead-code era, so fast-path ok is the right
+    %% shape here.
+    ?assertEqual(ok, marina_cache:erase(pool_a, <<"never-cached">>)).
+
+erase_pool_removes_all_for_pool() ->
+    ok = marina_cache:put(pool_b, <<"q1">>, <<"id1">>),
+    ok = marina_cache:put(pool_b, <<"q2">>, <<"id2">>),
+    ok = marina_cache:put(pool_b, <<"q3">>, <<"id3">>),
+    ?assertEqual(3, marina_cache:erase_pool(pool_b)),
+    ?assertEqual({error, not_found}, marina_cache:get(pool_b, <<"q1">>)),
+    ?assertEqual({error, not_found}, marina_cache:get(pool_b, <<"q2">>)),
+    ?assertEqual({error, not_found}, marina_cache:get(pool_b, <<"q3">>)).
+
+erase_pool_leaves_other_pools_alone() ->
+    ok = marina_cache:put(pool_c, <<"q1">>, <<"id_c">>),
+    ok = marina_cache:put(pool_d, <<"q1">>, <<"id_d">>),
+    ?assertEqual(1, marina_cache:erase_pool(pool_c)),
+    ?assertEqual({error, not_found}, marina_cache:get(pool_c, <<"q1">>)),
+    ?assertEqual({ok, <<"id_d">>}, marina_cache:get(pool_d, <<"q1">>)).

--- a/test/marina_frame_tests.erl
+++ b/test/marina_frame_tests.erl
@@ -1,0 +1,61 @@
+-module(marina_frame_tests).
+
+-include("test.hrl").
+
+encode_decode_roundtrip_test_() ->
+    [{lists:flatten(io_lib:format(
+        "stream=~p flags=~p opcode=~p body_size=~p",
+        [Stream, Flags, Opcode, byte_size(Body)])),
+      fun () -> assert_roundtrip(Stream, Flags, Opcode, Body) end}
+     || Stream <- [0, 1, -1, ?MAX_STREAM_ID - 1],
+        Flags <- [0, 1, 2, 4, 8, 15],
+        Opcode <- [?OP_QUERY, ?OP_RESULT, ?OP_EVENT, ?OP_BATCH],
+        Body <- [<<>>, <<"x">>, crypto:strong_rand_bytes(4096)]].
+
+assert_roundtrip(Stream, Flags, Opcode, Body) ->
+    Encoded = iolist_to_binary(marina_frame:encode(#frame {
+        stream = Stream,
+        flags = Flags,
+        opcode = Opcode,
+        body = Body
+    })),
+    %% encode/1 emits with the request bit (high bit = 0); decode/1
+    %% only parses response frames (high bit = 1). Flip it to simulate
+    %% the server side echoing the same body back.
+    {<<>>, [Decoded]} = marina_frame:decode(flip_to_response(Encoded)),
+    ?assertEqual(Stream, Decoded#frame.stream),
+    ?assertEqual(Flags, Decoded#frame.flags),
+    ?assertEqual(Opcode, Decoded#frame.opcode),
+    ?assertEqual(Body, Decoded#frame.body).
+
+flip_to_response(<<V:8, Rest/binary>>) ->
+    <<(V bor 16#80):8, Rest/binary>>.
+
+decode_splits_multiple_frames_test() ->
+    F1 = flip_to_response(iolist_to_binary(marina_frame:encode(
+        #frame {stream = 1, flags = 0, opcode = ?OP_READY, body = <<>>}))),
+    F2 = flip_to_response(iolist_to_binary(marina_frame:encode(
+        #frame {stream = 2, flags = 0, opcode = ?OP_READY, body = <<"ok">>}))),
+    {<<>>, [D2, D1]} = marina_frame:decode(<<F1/binary, F2/binary>>),
+    ?assertEqual(1, D1#frame.stream),
+    ?assertEqual(2, D2#frame.stream).
+
+decode_leaves_partial_frame_in_rest_test() ->
+    Full = flip_to_response(iolist_to_binary(marina_frame:encode(#frame {
+        stream = 1, flags = 0, opcode = ?OP_READY, body = <<"abcdef">>
+    }))),
+    %% Slice off the last 3 bytes so the frame header parses but the
+    %% body is short. decode/1 should return [] and keep the partial.
+    Short = binary:part(Full, 0, byte_size(Full) - 3),
+    {Rest, []} = marina_frame:decode(Short),
+    ?assertEqual(Short, Rest).
+
+pending_size_knows_wire_length_test() ->
+    Response = flip_to_response(iolist_to_binary(marina_frame:encode(#frame {
+        stream = 7, flags = 0, opcode = ?OP_READY, body = <<"hello">>
+    }))),
+    ?assertEqual(byte_size(Response), marina_frame:pending_size(Response)).
+
+pending_size_undefined_for_partial_header_test() ->
+    ?assertEqual(undefined, marina_frame:pending_size(<<>>)),
+    ?assertEqual(undefined, marina_frame:pending_size(<<16#84, 0, 0>>)).

--- a/test/marina_tests.erl
+++ b/test/marina_tests.erl
@@ -1,300 +1,294 @@
 -module(marina_tests).
+
 -include("test.hrl").
 
 -define(IP, "172.18.0.2").
 
-%% runners
+%% --- test generators ------------------------------------------------
+
 marina_test_() ->
-    {setup,
-        fun () -> setup([
-            {ip, ?IP},
-            {keyspace, <<"test">>},
-            {pool_size, 1}
-        ]) end,
-        fun (_) -> cleanup() end,
-    {inparallel, [
-        fun async_query_subtest/0,
-        fun async_reusable_query_subtest/0,
-        fun async_reusable_query_invalid_query_subtest/0,
-        fun batch_subtest/0,
-        fun counters_subtest/0,
-        fun paging_subtest/0,
-        fun query_subtest/0,
-        fun query_metedata_types_subtest/0,
-        fun query_no_metadata_subtest/0,
-        fun reusable_query_subtest/0,
-        fun reusable_query_invalid_query_subtest/0,
-        fun schema_changes_subtest/0,
-        fun tuples_subtest/0
-    ]}}.
+    marina_suite([], [
+        fun async_query/0,
+        fun async_reusable_query/0,
+        fun async_reusable_query_invalid/0,
+        fun batch/0,
+        fun counters/0,
+        fun paging/0,
+        fun query/0,
+        fun query_data_types/0,
+        fun query_skip_metadata/0,
+        fun reusable_query/0,
+        fun reusable_query_invalid/0,
+        fun schema_change_udt/0,
+        fun tuples/0
+    ]).
 
 marina_compression_test_() ->
+    marina_suite([{compression, true}], [fun query/0]).
+
+%% --- setup ----------------------------------------------------------
+
+marina_suite(ExtraEnv, Tests) ->
     {setup,
-        fun () -> setup([
-            {ip, ?IP},
-            {compression, true},
-            {keyspace, <<"test">>}
-        ]) end,
-        fun (_) -> cleanup() end,
-        [fun query_subtest/0]
-    }.
+        fun () -> start(ExtraEnv) end,
+        fun (_) -> marina_app:stop() end,
+        {inparallel, Tests}}.
 
-%% tests
-async_query_subtest() ->
-    {ok, Ref} = marina:async_query(?QUERY1, #{}),
-    Response = marina:receive_response(Ref),
+start(ExtraEnv) ->
+    error_logger:tty(false),
+    application:load(marina),
+    application:set_env(marina, ip, ?IP),
+    application:set_env(marina, keyspace, <<"test">>),
+    [application:set_env(marina, K, V) || {K, V} <- ExtraEnv],
+    marina_app:start(),
+    timer:sleep(250),
+    ensure_base_schema().
 
-    ?assertEqual(?QUERY1_RESULT, Response).
+ensure_base_schema() ->
+    q(<<"CREATE KEYSPACE IF NOT EXISTS test WITH REPLICATION ="
+        " {'class':'SimpleStrategy', 'replication_factor':1};">>),
+    q(<<"CREATE TABLE IF NOT EXISTS test.users ("
+        " key uuid, column1 text, column2 text, value blob,"
+        " PRIMARY KEY (key, column1, column2));">>),
+    q(<<"INSERT INTO test.users (key, column1, column2, value) VALUES"
+        " (99492dfe-d94a-11e4-af39-58f44110757d, 'test', 'test2',"
+        " intAsBlob(0));">>).
 
-async_reusable_query_subtest() ->
-    {ok, Ref} = marina:async_reusable_query(?QUERY3, #{}),
-    Response = marina:receive_response(Ref),
-    {ok, Ref2} = marina:async_reusable_query(?QUERY2,
-        #{values => ?QUERY2_VALUES}),
-    Response = marina:receive_response(Ref2),
-    {ok, Ref3} = marina:async_reusable_query(?QUERY2,
-        #{values => ?QUERY2_VALUES}),
-    Response = marina:receive_response(Ref3),
+%% --- API helpers ----------------------------------------------------
 
-    ?assertEqual(?QUERY1_RESULT, Response).
+opts() ->
+    #{consistency_level => ?CONSISTENCY_LOCAL_ONE, timeout => ?TIMEOUT}.
 
-async_reusable_query_invalid_query_subtest() ->
-    Query = <<"SELECT * FROM user LIMIT 1;">>,
-    {error, {8704, _}} = marina:async_reusable_query(Query, #{}).
+opts(Extra) ->
+    maps:merge(opts(), Extra).
 
-batch_subtest() ->
-    query(<<"DROP TABLE test.batch_rows;">>),
-    query(<<"CREATE TABLE test.batch_rows (k int PRIMARY KEY, v text);">>),
+q(Query)         -> marina:query(Query, opts()).
+q(Query, Extra)  -> marina:query(Query, opts(Extra)).
 
-    %% LOGGED batch of two raw INSERTs
-    {ok, undefined} = marina:batch([
-        {query, <<"INSERT INTO test.batch_rows (k, v) VALUES (1, 'a')">>, []},
-        {query, <<"INSERT INTO test.batch_rows (k, v) VALUES (2, 'b')">>, []}
-    ], #{batch_type => logged,
-         consistency_level => ?CONSISTENCY_LOCAL_ONE,
-         timeout => ?TIMEOUT}),
-    {ok, {result, _, 2, _}} = query(<<"SELECT * FROM test.batch_rows;">>),
+rq(Query)        -> marina:reusable_query(Query, opts()).
+rq(Query, Extra) -> marina:reusable_query(Query, opts(Extra)).
 
-    %% Warm the prepared-statement cache, then pull the id out to feed a batch
-    InsertPrepared =
-        <<"INSERT INTO test.batch_rows (k, v) VALUES (?, ?)">>,
-    {ok, _} = marina:reusable_query(InsertPrepared,
-        #{values => [marina_types:encode_int(3), <<"c">>],
-          consistency_level => ?CONSISTENCY_LOCAL_ONE,
-          timeout => ?TIMEOUT}),
-    {ok, Pool} = marina_pool:node(undefined),
-    {ok, StatementId} = marina_cache:get(Pool, InsertPrepared),
+aq(Query)        -> marina:async_query(Query, opts()).
+arq(Query)       -> marina:async_reusable_query(Query, opts()).
+arq(Query, Extra)-> marina:async_reusable_query(Query, opts(Extra)).
 
-    %% UNLOGGED batch mixing a prepared statement and a raw query
-    {ok, undefined} = marina:batch([
-        {prepared, StatementId,
-            [marina_types:encode_int(4), <<"d">>]},
-        {query, <<"INSERT INTO test.batch_rows (k, v) VALUES (5, 'e')">>, []}
-    ], #{batch_type => unlogged,
-         consistency_level => ?CONSISTENCY_LOCAL_ONE,
-         timeout => ?TIMEOUT}),
-    {ok, {result, _, 5, _}} = query(<<"SELECT * FROM test.batch_rows;">>),
+b(Queries, Extra) -> marina:batch(Queries, opts(Extra)).
 
-    query(<<"DROP TABLE test.batch_rows;">>).
+with_scratch(Name, DDL, Fun) ->
+    Drop = <<"DROP TABLE IF EXISTS test.", Name/binary, ";">>,
+    q(Drop),
+    q(DDL),
+    try Fun() after q(Drop) end.
 
-counters_subtest() ->
-    query(<<"DROP TABLE test.page_view_counts;">>),
-    query(<<"CREATE TABLE test.page_view_counts (counter_value counter,
-        url_name varchar, page_name varchar,
-        PRIMARY KEY (url_name, page_name));">>),
-    query(<<"UPDATE test.page_view_counts SET counter_value = counter_value + 1
-        WHERE url_name='adgear.com' AND page_name='home';">>),
-    Response = query(<<"SELECT * FROM test.page_view_counts">>),
+%% --- tests ----------------------------------------------------------
 
-    ?assertEqual({ok, {result,
-        {result_metadata, 3,
-            [{column_spec, <<"test">>, <<"page_view_counts">>, <<"url_name">>,
-                varchar},
-             {column_spec, <<"test">>, <<"page_view_counts">>, <<"page_name">>,
-                 varchar},
-             {column_spec, <<"test">>, <<"page_view_counts">>,
-                 <<"counter_value">>, counter}],
-            undefined},
-        1,
-        [[<<"adgear.com">>, <<"home">>, <<0, 0, 0, 0, 0, 0, 0, 1>>]]
-    }}, Response).
+async_query() ->
+    {ok, Ref} = aq(?QUERY1),
+    ?assertEqual(?QUERY1_RESULT, marina:receive_response(Ref)).
 
-paging_subtest() ->
-    query(<<"INSERT INTO test.users (key, column1, column2, value) values
-        (99492dfe-d94a-11e4-af39-58f44110757e, 'test', 'test2',
-        intAsBlob(0));">>),
+async_reusable_query() ->
+    {ok, R1} = arq(?QUERY3),
+    ?QUERY1_RESULT = marina:receive_response(R1),
+    {ok, R2} = arq(?QUERY2, #{values => ?QUERY2_VALUES}),
+    ?QUERY1_RESULT = marina:receive_response(R2),
+    {ok, R3} = arq(?QUERY2, #{values => ?QUERY2_VALUES}),
+    ?assertEqual(?QUERY1_RESULT, marina:receive_response(R3)).
+
+async_reusable_query_invalid() ->
+    ?assertMatch({error, {8704, _}},
+        marina:async_reusable_query(<<"SELECT * FROM user LIMIT 1;">>, #{})).
+
+batch() ->
+    with_scratch(<<"batch_rows">>,
+        <<"CREATE TABLE test.batch_rows (k int PRIMARY KEY, v text);">>,
+        fun () ->
+            %% LOGGED batch of raw inserts
+            {ok, undefined} = b([
+                {query, <<"INSERT INTO test.batch_rows (k, v) VALUES (1, 'a')">>, []},
+                {query, <<"INSERT INTO test.batch_rows (k, v) VALUES (2, 'b')">>, []}
+            ], #{batch_type => logged}),
+            ?assertMatch({ok, {result, _, 2, _}},
+                q(<<"SELECT * FROM test.batch_rows;">>)),
+
+            %% Warm cache + pull prepared id, then UNLOGGED with mixed kinds
+            Insert = <<"INSERT INTO test.batch_rows (k, v) VALUES (?, ?)">>,
+            {ok, _} = rq(Insert,
+                #{values => [marina_types:encode_int(3), <<"c">>]}),
+            {ok, Pool} = marina_pool:node(undefined),
+            {ok, StatementId} = marina_cache:get(Pool, Insert),
+            {ok, undefined} = b([
+                {prepared, StatementId,
+                    [marina_types:encode_int(4), <<"d">>]},
+                {query, <<"INSERT INTO test.batch_rows (k, v) VALUES (5, 'e')">>, []}
+            ], #{batch_type => unlogged}),
+            ?assertMatch({ok, {result, _, 5, _}},
+                q(<<"SELECT * FROM test.batch_rows;">>))
+        end).
+
+counters() ->
+    with_scratch(<<"page_view_counts">>,
+        <<"CREATE TABLE test.page_view_counts ("
+          " counter_value counter,"
+          " url_name varchar,"
+          " page_name varchar,"
+          " PRIMARY KEY (url_name, page_name));">>,
+        fun () ->
+            q(<<"UPDATE test.page_view_counts SET"
+                " counter_value = counter_value + 1"
+                " WHERE url_name='adgear.com' AND page_name='home';">>),
+            ?assertEqual({ok, {result,
+                {result_metadata, 3,
+                    [{column_spec, <<"test">>, <<"page_view_counts">>,
+                        <<"url_name">>, varchar},
+                     {column_spec, <<"test">>, <<"page_view_counts">>,
+                        <<"page_name">>, varchar},
+                     {column_spec, <<"test">>, <<"page_view_counts">>,
+                        <<"counter_value">>, counter}],
+                    undefined},
+                1,
+                [[<<"adgear.com">>, <<"home">>, <<0, 0, 0, 0, 0, 0, 0, 1>>]]}},
+                q(<<"SELECT * FROM test.page_view_counts">>))
+        end).
+
+paging() ->
+    q(<<"INSERT INTO test.users (key, column1, column2, value) VALUES"
+        " (99492dfe-d94a-11e4-af39-58f44110757e, 'test', 'test2',"
+        " intAsBlob(0));">>),
     Query = <<"SELECT * FROM users LIMIT 10;">>,
-    {ok, {result, Metadata, 1, Rows}} = marina:query(Query,
-        #{page_size => 1}),
-    {result_metadata, 4, _, PagingState} = Metadata,
+    {ok, {result, M1, 1, R1}} = q(Query, #{page_size => 1}),
+    {result_metadata, 4, _, State1} = M1,
+    {ok, {result, M2, 1, R2}} = q(Query,
+        #{page_size => 1, paging_state => State1}),
+    {result_metadata, 4, _, State2} = M2,
+    ?assertNotEqual(State1, State2),
+    ?assertNotEqual(R1, R2).
 
-    {ok, {result, Metadata2, 1, Rows2}} = marina:query(Query,
-         #{page_size => 1, paging_state => PagingState}),
-    {result_metadata, 4, _, PagingState2} = Metadata2,
+query() ->
+    ?assertEqual(?QUERY1_RESULT, q(?QUERY1)).
 
-    ?assertNotEqual(PagingState, PagingState2),
-    ?assertNotEqual(Rows, Rows2).
-
-query_subtest() ->
-    Response = query(?QUERY1),
-    ?assertEqual(?QUERY1_RESULT, Response).
-
-query_metedata_types_subtest() ->
-    query(<<"DROP TABLE types;">>),
-    Columns = datatypes_columns(?DATA_TYPES),
-    Query = <<"CREATE TABLE types (",  Columns/binary, " PRIMARY KEY(col1));">>,
-    Response = query(Query),
-    ?assertEqual({ok, {<<"CREATED">>, <<"TABLE">>, {<<"test">>, <<"types">>}}},
-        Response),
+query_data_types() ->
+    q(<<"DROP TABLE IF EXISTS test.types;">>),
+    ColumnDefs = build_column_defs(?DATA_TYPES),
+    q(<<"CREATE TABLE test.types (", ColumnDefs/binary,
+        " PRIMARY KEY(col1));">>),
 
     Values = [
         <<"hello">>,
         marina_types:encode_long(100000),
         <<"blob">>,
         marina_types:encode_boolean(true)
-    ] ,
-    Response2 = marina:query(<<"INSERT INTO types (col1, col2, col3, col4)
-        VALUES (?, ?, ?, ?)">>, #{values => Values}),
+    ],
+    ?assertEqual({ok, undefined},
+        q(<<"INSERT INTO test.types (col1, col2, col3, col4)"
+            " VALUES (?, ?, ?, ?)">>, #{values => Values})),
 
-    ?assertEqual({ok, undefined}, Response2),
-
-    Response3 = query(<<"SELECT * FROM types LIMIT 1;">>),
-
+    ExpectedRow = [
+        <<"hello">>,                       %% col1 (ascii)
+        null, null, null, null, null,      %% col10..col14
+        null, null, null,                  %% col15..col17
+        <<0, 0, 0, 0, 0, 1, 134, 160>>,    %% col2 (bigint 100000)
+        <<"blob">>,                        %% col3
+        <<1>>,                             %% col4 (boolean true)
+        null, null, null, null, null       %% col5..col9
+    ],
+    ExpectedMetadata = expected_types_metadata(?DATA_TYPES),
     ?assertEqual({ok, {result,
-        {result_metadata, 17,
-            [{column_spec, <<"test">>, <<"types">>, <<"col1">>, ascii},
-             {column_spec, <<"test">>, <<"types">>, <<"col10">>, uid},
-             {column_spec, <<"test">>, <<"types">>, <<"col11">>, varchar},
-             {column_spec, <<"test">>, <<"types">>, <<"col12">>, varint},
-             {column_spec, <<"test">>, <<"types">>, <<"col13">>, timeuuid},
-             {column_spec, <<"test">>, <<"types">>, <<"col14">>, inet},
-             {column_spec, <<"test">>, <<"types">>, <<"col15">>,
-                 {list, varchar}},
-             {column_spec, <<"test">>, <<"types">>, <<"col16">>,
-                 {map, varchar, varchar}},
-             {column_spec, <<"test">>, <<"types">>, <<"col17">>,
-                 {set, varchar}},
-             {column_spec, <<"test">>, <<"types">>, <<"col2">>, bigint},
-             {column_spec, <<"test">>, <<"types">>, <<"col3">>, blob},
-             {column_spec, <<"test">>, <<"types">>, <<"col4">>, boolean},
-             {column_spec, <<"test">>, <<"types">>, <<"col5">>, decimal},
-             {column_spec, <<"test">>, <<"types">>, <<"col6">>, double},
-             {column_spec, <<"test">>, <<"types">>, <<"col7">>, float},
-             {column_spec, <<"test">>, <<"types">>, <<"col8">>, int},
-             {column_spec, <<"test">>, <<"types">>, <<"col9">>, timestamp}],
+        {result_metadata, length(?DATA_TYPES), ExpectedMetadata, undefined},
+        1, [ExpectedRow]}},
+        q(<<"SELECT * FROM test.types LIMIT 1;">>)).
+
+query_skip_metadata() ->
+    ?assertEqual({ok, {result,
+        {result_metadata, 4, [], undefined}, 1,
+        [[<<153, 73, 45, 254, 217, 74, 17, 228, 175, 57, 88,
+            244, 65, 16, 117, 125>>,
+          <<"test">>, <<"test2">>, <<0, 0, 0, 0>>]]}},
+        q(?QUERY1, #{skip_metadata => true})).
+
+reusable_query() ->
+    R = rq(?QUERY1),
+    R = rq(?QUERY1),
+    R = rq(?QUERY2, #{values => ?QUERY2_VALUES}),
+    ?assertEqual(?QUERY1_RESULT, R).
+
+reusable_query_invalid() ->
+    ?assertMatch({error, {8704, _}},
+        marina:reusable_query(<<"SELECT * FROM user LIMIT 1;">>, #{})).
+
+schema_change_udt() ->
+    q(<<"DROP KEYSPACE IF EXISTS test2;">>),
+    q(<<"CREATE KEYSPACE test2 WITH REPLICATION ="
+        " {'class':'SimpleStrategy', 'replication_factor':1};">>),
+    q(<<"CREATE TYPE test2.address ("
+        " street text, city text, zip_code int, phones set<text>);">>),
+    q(<<"CREATE TABLE test2.users ("
+        " key uuid, column1 text,"
+        " column2 frozen<test2.address>, value blob,"
+        " PRIMARY KEY (key, column1, column2));">>),
+    ?assertEqual({ok, {result,
+        {result_metadata, 4,
+            [{column_spec, <<"test2">>, <<"users">>, <<"key">>, uid},
+             {column_spec, <<"test2">>, <<"users">>, <<"column1">>, varchar},
+             {column_spec, <<"test2">>, <<"users">>, <<"column2">>,
+                 {udt, <<"test2">>, <<"address">>,
+                     [{<<"street">>, varchar},
+                      {<<"city">>, varchar},
+                      {<<"zip_code">>, int},
+                      {<<"phones">>, {set, varchar}}]}},
+             {column_spec, <<"test2">>, <<"users">>, <<"value">>, blob}],
             undefined},
-        1,
-        [[<<"hello">>, null, null, null, null, null, null, null, null,
-            <<0, 0, 0, 0, 0, 1, 134, 160>>, <<"blob">>, <<1>>, null, null,
-            null, null, null]]
-    }}, Response3).
+        0, []}},
+        q(<<"SELECT * FROM test2.users LIMIT 1;">>)),
+    q(<<"DROP TABLE test2.users;">>),
+    q(<<"DROP KEYSPACE test2;">>).
 
-query_no_metadata_subtest() ->
-    Response2 = marina:query(?QUERY1, #{skip_metadata => true}),
+tuples() ->
+    with_scratch(<<"collect_things">>,
+        <<"CREATE TABLE test.collect_things ("
+          " k int PRIMARY KEY,"
+          " v frozen<tuple<int, text, float>>);">>,
+        fun () ->
+            ?assertEqual({ok, {result,
+                {result_metadata, 2,
+                    [{column_spec, <<"test">>, <<"collect_things">>,
+                        <<"k">>, int},
+                     {column_spec, <<"test">>, <<"collect_things">>,
+                        <<"v">>, {tuple, [int, varchar, float]}}],
+                    undefined},
+                0, []}},
+                q(<<"SELECT * FROM test.collect_things;">>))
+        end).
 
-    ?assertEqual({ok, {result,
-    {result_metadata, 4, [], undefined}, 1, [
-        [<<153, 73, 45, 254, 217, 74, 17, 228, 175, 57, 88, 244, 65, 16, 117,
-            125>>, <<"test">>, <<"test2">>, <<0, 0, 0, 0>>]
-    ]}}, Response2).
+%% --- data-types fixtures --------------------------------------------
 
-reusable_query_subtest() ->
-    Response = marina:reusable_query(?QUERY1, #{}),
-    Response = marina:reusable_query(?QUERY1, #{}),
-    Response = marina:reusable_query(?QUERY2, #{values => ?QUERY2_VALUES}),
+build_column_defs(Types) ->
+    Indexed = lists:zip(lists:seq(1, length(Types)), Types),
+    iolist_to_binary(
+        [io_lib:format("col~B ~s, ", [I, T]) || {I, T} <- Indexed]).
 
-    ?assertEqual(?QUERY1_RESULT, Response).
+expected_types_metadata(Types) ->
+    Indexed = lists:zip(lists:seq(1, length(Types)), Types),
+    Sorted = lists:sort(fun ({I1, _}, {I2, _}) ->
+        integer_to_list(I1) =< integer_to_list(I2)
+    end, Indexed),
+    [{column_spec, <<"test">>, <<"types">>,
+        list_to_binary("col" ++ integer_to_list(I)),
+        type_atom(T)} || {I, T} <- Sorted].
 
-reusable_query_invalid_query_subtest() ->
-    Query = <<"SELECT * FROM user LIMIT 1;">>,
-    {error, {8704, _}} = marina:reusable_query(Query, #{}).
-
-schema_changes_subtest() ->
-    query(<<"DROP KEYSPACE test2;">>),
-    query(<<"CREATE KEYSPACE test2 WITH REPLICATION =
-        {'class':'SimpleStrategy', 'replication_factor':1};">>),
-    query(<<"CREATE TYPE test2.address (street text, city text, zip_code int,
-        phones set<text>);">>),
-    query(<<"CREATE TABLE test2.users (key uuid, column1 text,
-        column2 frozen<test2.address>, value blob, PRIMARY KEY
-        (key, column1, column2));">>),
-    Response = query(<<"SELECT * FROM test2.users LIMIT 1;">>),
-
-    ?assertEqual({ok, {result,
-    {result_metadata, 4,
-        [{column_spec, <<"test2">>, <<"users">>, <<"key">>, uid},
-         {column_spec, <<"test2">>, <<"users">>, <<"column1">>, varchar},
-         {column_spec, <<"test2">>, <<"users">>, <<"column2">>,
-             {udt, <<"test2">>, <<"address">>,
-                 [{<<"street">>, varchar},
-                  {<<"city">>, varchar},
-                  {<<"zip_code">>, int},
-                  {<<"phones">>, {set, varchar}}]}},
-         {column_spec, <<"test2">>, <<"users">>, <<"value">>, blob}],
-             undefined},
-    0, []}}, Response),
-
-    query(<<"DROP TABLE test2.users;">>),
-    query(<<"DROP KEYSPACE test2;">>).
-
-tuples_subtest() ->
-    query(<<"CREATE TABLE collect_things (k int PRIMARY KEY,
-        v frozen <tuple<int, text, float>>);">>),
-    Response = query(<<"SELECT * FROM test.collect_things;">>),
-
-    ?assertEqual({ok, {result,
-        {result_metadata, 2,
-            [{column_spec, <<"test">>, <<"collect_things">>, <<"k">>, int},
-             {column_spec, <<"test">>, <<"collect_things">>, <<"v">>,
-                 {tuple, [int, varchar, float]}}],
-            undefined},
-    0, []}}, Response),
-
-    query(<<"DROP TABLE collect_things;">>).
-
-%% utils
-bootstrap() ->
-    application:load(marina),
-    application:set_env(?APP, ip, ?IP),
-    marina_app:start(),
-    timer:sleep(500),
-    query(<<"CREATE KEYSPACE test WITH REPLICATION =
-        {'class':'SimpleStrategy', 'replication_factor':1};">>),
-    query(<<"CREATE TABLE test.users (key uuid, column1 text,
-        column2 text, value blob, PRIMARY KEY (key, column1, column2));">>),
-    query(<<"INSERT INTO test.users (key, column1, column2, value)
-        values (99492dfe-d94a-11e4-af39-58f44110757d, 'test', 'test2',
-        intAsBlob(0))">>),
-    marina_app:stop().
-
-cleanup() ->
-    marina_app:stop().
-
-datatypes_columns(Cols) ->
-    list_to_binary(datatypes_columns(1, Cols)).
-
-datatypes_columns(_I, []) ->
-    [];
-datatypes_columns(I, [ColumnType|Rest]) ->
-    Column = io_lib:format("col~B ~s, ", [I, ColumnType]),
-    [Column | datatypes_columns(I + 1, Rest)].
-
-query(Query) ->
-    marina:query(Query, #{
-        consistency_level => ?CONSISTENCY_LOCAL_ONE,
-        timeout => ?TIMEOUT
-    }).
-
-setup(KeyVals) ->
-    error_logger:tty(false),
-    bootstrap(),
-    application:load(marina),
-    set_env(KeyVals),
-    marina_app:start(),
-    timer:sleep(250).
-
-set_env([]) ->
-    ok;
-set_env([{K, V} | T]) ->
-    application:set_env(?APP, K, V),
-    set_env(T).
+type_atom(ascii)             -> ascii;
+type_atom(bigint)            -> bigint;
+type_atom(blob)              -> blob;
+type_atom(boolean)           -> boolean;
+type_atom(decimal)           -> decimal;
+type_atom(double)            -> double;
+type_atom(float)             -> float;
+type_atom(inet)              -> inet;
+type_atom(int)               -> int;
+type_atom('list<text>')      -> {list, varchar};
+type_atom('map<text, text>') -> {map, varchar, varchar};
+type_atom('set<text>')       -> {set, varchar};
+type_atom(timestamp)         -> timestamp;
+type_atom(timeuuid)          -> timeuuid;
+type_atom(uuid)              -> uid;
+type_atom(varchar)           -> varchar;
+type_atom(varint)            -> varint.

--- a/test/marina_tests.erl
+++ b/test/marina_tests.erl
@@ -36,13 +36,24 @@ marina_suite(ExtraEnv, Tests) ->
 
 start(ExtraEnv) ->
     error_logger:tty(false),
+    %% Phase 1: start marina without a default keyspace and seed the
+    %% `test` schema. Without this, every connection's `USE test` would
+    %% fail against a fresh server — USE runs inside shackle's per-
+    %% connection setup, so a missing keyspace means zero working
+    %% connections and `{error, no_server}` from every test.
     application:load(marina),
     application:set_env(marina, ip, ?IP),
+    application:set_env(marina, keyspace, undefined),
+    marina_app:start(),
+    timer:sleep(500),
+    ensure_base_schema(),
+    marina_app:stop(),
+    %% Phase 2: restart with the caller's ExtraEnv (and the default
+    %% keyspace) on top of a now-ready schema.
     application:set_env(marina, keyspace, <<"test">>),
     [application:set_env(marina, K, V) || {K, V} <- ExtraEnv],
     marina_app:start(),
-    timer:sleep(250),
-    ensure_base_schema().
+    timer:sleep(250).
 
 ensure_base_schema() ->
     q(<<"CREATE KEYSPACE IF NOT EXISTS test WITH REPLICATION ="


### PR DESCRIPTION
## Summary

Two atomic commits on top of #68.

**1. Rewrite marina_tests for DRY and structure.** Same integration coverage, cleaner shape — no rewrite of behavior, just the test code.

- Shared defaults come from \`opts/0\` and \`opts/1\` so no test re-spells \`consistency_level\` / \`timeout\` in its own map.
- \`q/1\`, \`q/2\`, \`rq/1\`, \`rq/2\`, \`arq/1\`, \`arq/2\`, \`aq/1\`, \`b/2\` are one-line wrappers on the \`marina:*\` API with \`opts()\` merged in — reads like the CQL it is testing.
- \`marina_suite/2\` replaces the duplicated \`{setup, ..., inparallel}\` skeleton. The compression suite is now just \`marina_suite([{compression, true}], ...)\`.
- Scratch-table tests (batch, counters, tuples) go through \`with_scratch/3\` — DROP IF EXISTS, CREATE, run, DROP. No more inlined DDL boilerplate.
- The data-types test stops hand-enumerating 17 \`column_spec\` tuples in the expected metadata; \`expected_types_metadata/1\` + \`type_atom/1\` derives them from the same \`?DATA_TYPES\` list that builds the CREATE TABLE.
- \`setup/1\`'s bootstrap-then-restart dance is gone. A single \`start/1\` loads env, starts marina, then \`ensure_base_schema/0\` uses \`IF [NOT] EXISTS\` to stay idempotent on re-runs.

**2. Add unit tests for frame, buffer, cache, and event decoder.** Pure-Erlang tests that don't need a running cluster, so \`rebar3 eunit\` covers them on a cold checkout.

- \`marina_frame_tests\`: ~290 encode/decode roundtrip cases across Cartesian combinations of stream / flags / opcode / body size, plus split-frame / partial-header / pending-size edge cases. Flips the high bit on the version byte to simulate server-side echo since \`encode/1\` emits request frames and \`decode/1\` only parses responses.
- \`marina_buffer_tests\`: single-chunk, multi-chunk, partial-header, and byte-by-byte arrival through the stateful buffer.
- \`marina_cache_tests\`: \`put\` / \`get\` / \`erase\` semantics including the new \`erase_pool/1\` from the topology-refresh PR, covering the \"leaves other pools alone\" invariant.
- \`marina_body_tests\`: EVENT frame decoding for all four topology and status change kinds, IPv6 \`[inet]\` decoding to an 8-tuple, unknown-kind pass-through, and the schema-change raw-body contract that \`marina_control\` depends on.

Totals: 15 integration tests on master → **325 tests total** here. \`make xref\` + \`dialyzer\` + \`eunit\` all green. Cover analysis breakout per module visible via \`rebar3 cover -v\`.

Based on \`feat/batch-queries\` (#68); will rebase onto master once that merges.