### PR TITLE
CQL v4 spec compliance: flag order, FUNCTION/AGGREGATE, AUTH_CHALLENGE, string_list

### DIFF
--- a/src/marina_body.erl
+++ b/src/marina_body.erl
@@ -75,7 +75,14 @@ decode(?OP_RESULT, <<5:32/integer, Rest/binary>>) ->
     end,
 
     {ok, {ChangeType, Target, Options}};
+decode(?OP_AUTH_CHALLENGE, Body) ->
+    {Token, <<>>} = marina_types:decode_bytes(Body),
+    {ok, {auth_challenge, Token}};
 decode(?OP_AUTH_SUCCESS, _) ->
+    %% Spec allows a trailing [bytes] token here. marina's authenticate
+    %% path matches on {ok, undefined} so we keep the existing shape —
+    %% the token is only meaningful for SASL mechanisms that do a
+    %% multi-round handshake, which marina does not currently support.
     {ok, undefined};
 decode(?OP_EVENT, Body) ->
     {EventType, Rest} = marina_types:decode_string(Body),

--- a/src/marina_body.erl
+++ b/src/marina_body.erl
@@ -66,7 +66,12 @@ decode(?OP_RESULT, <<5:32/integer, Rest/binary>>) ->
         <<"TYPE">> ->
             {Option, Rest4} = marina_types:decode_string(Rest3),
             {Option2, <<>>} = marina_types:decode_string(Rest4),
-            {Option, Option2}
+            {Option, Option2};
+        Fn when Fn =:= <<"FUNCTION">>; Fn =:= <<"AGGREGATE">> ->
+            {Keyspace, Rest4} = marina_types:decode_string(Rest3),
+            {Name, Rest5} = marina_types:decode_string(Rest4),
+            {ArgTypes, <<>>} = marina_types:decode_string_list(Rest5),
+            {Keyspace, Name, ArgTypes}
     end,
 
     {ok, {ChangeType, Target, Options}};

--- a/src/marina_body.erl
+++ b/src/marina_body.erl
@@ -13,9 +13,11 @@
 
 decode(#frame {flags = Flags, body = Body, opcode = Opcode}) ->
     Body1 = maybe_decompress(Flags, Body),
+    %% Spec order inside a flagged response body:
+    %%   [tracing_id][warnings][custom_payload]<message>
     Body2 = skip_tracing(Flags, Body1),
-    Body3 = skip_custom_payload(Flags, Body2),
-    Body4 = skip_warnings(Flags, Body3),
+    Body3 = skip_warnings(Flags, Body2),
+    Body4 = skip_custom_payload(Flags, Body3),
     decode(Opcode, Body4).
 
 %% private

--- a/src/marina_request.erl
+++ b/src/marina_request.erl
@@ -109,7 +109,8 @@ query(Stream, FrameFlags, Query, QueryOpts) ->
 -spec register(stream(), frame_flag(), [binary()]) -> iolist().
 
 register(Stream, FrameFlags, EventTypes) ->
-    Body = encode_body(FrameFlags, [encode_string_list(EventTypes)]),
+    Body = encode_body(FrameFlags,
+        [marina_types:encode_string_list(EventTypes)]),
 
     marina_frame:encode(#frame {
         stream = Stream,
@@ -155,13 +156,6 @@ encode_batch_query({prepared, StatementId, Values}) ->
 encode_batch_values(Values) ->
     [marina_types:encode_short(length(Values)),
      [marina_types:encode_bytes(V) || V <- Values]].
-
-%% Spec-correct [string list] encoder — a [short] n followed by n [string].
-%% marina_types:encode_string_list/1 prefixes with an [int], which does not
-%% match the CQL wire format and would make the server reject REGISTER.
-encode_string_list(Values) ->
-    Parts = [marina_types:encode_string(V) || V <- Values],
-    iolist_to_binary([marina_types:encode_short(length(Values)), Parts]).
 
 flags(QueryOpts) ->
     {Mask1, Values} = values_flag(QueryOpts),

--- a/src/marina_types.erl
+++ b/src/marina_types.erl
@@ -100,7 +100,7 @@ decode_string(Bin) ->
 
 -spec decode_string_list(binary()) -> {[binary()], binary()}.
 
-decode_string_list(<<Length:32, Rest/binary>>) ->
+decode_string_list(<<Length:16, Rest/binary>>) ->
     decode_string_list(Rest, Length, []).
 
 -spec decode_string_map(binary()) -> {[{binary(), binary()}], binary()}.
@@ -185,7 +185,7 @@ encode_string(Value) ->
 
 encode_string_list(Values) ->
     EncodedValues = [encode_string(Value) || Value <- Values],
-    iolist_to_binary([encode_int(length(Values)), EncodedValues]).
+    iolist_to_binary([encode_short(length(Values)), EncodedValues]).
 
 -spec encode_string_map([{binary(), binary()}]) -> binary().
 
@@ -216,7 +216,7 @@ decode_long_string_set(Bin, Length, Acc) ->
 
 decode_string_list(Bin, 0, Acc) ->
     {lists:reverse(Acc), Bin};
-decode_string_list(<<Pos:32, String:Pos/binary, Rest/binary>>, Length, Acc) ->
+decode_string_list(<<Pos:16, String:Pos/binary, Rest/binary>>, Length, Acc) ->
     decode_string_list(Rest, Length - 1, [String | Acc]).
 
 decode_string_map(Bin, 0, Acc) ->

--- a/test/marina_body_tests.erl
+++ b/test/marina_body_tests.erl
@@ -64,6 +64,68 @@ schema_change_is_passed_through_raw_test() ->
     %% that decoder later.
     ?assertMatch(<<_:16, "CREATED", _:16, "KEYSPACE", _:16, "test2">>, Raw).
 
+flag_preambles_decoded_in_spec_order_test() ->
+    %% Spec order inside a response body when multiple flag bits are set:
+    %%   [tracing_id (0x02)][warnings (0x08)][custom_payload (0x04)][message]
+    %% Build a READY response with all three preambles and assert the
+    %% body decoder consumes them in that order — reordering would either
+    %% crash on length mismatch or read the wrong bytes as the message.
+    TracingUuid = <<1:128>>,
+    Warnings = <<(byte_size(<<"slow query">>)):16, "slow query">>,
+    CustomPayload = <<>>,
+    Body = <<TracingUuid/binary,
+             1:16, Warnings/binary,        %% 1 warning string
+             0:16, CustomPayload/binary>>, %% empty custom_payload map
+    Flags = 16#02 bor 16#04 bor 16#08,
+    ?assertEqual({ok, undefined},
+        marina_body:decode(#frame {
+            flags = Flags,
+            stream = 0,
+            opcode = ?OP_READY,
+            body = Body
+        })).
+
+result_schema_change_function_test() ->
+    %% CREATE FUNCTION response: target=FUNCTION, options =
+    %%   <string keyspace><string name><string list arg_types>
+    Body = <<5:32,                               %% kind = SCHEMA_CHANGE
+             (encode_string(<<"CREATED">>))/binary,
+             (encode_string(<<"FUNCTION">>))/binary,
+             (encode_string(<<"test">>))/binary,
+             (encode_string(<<"add">>))/binary,
+             2:16,
+             (encode_string(<<"int">>))/binary,
+             (encode_string(<<"int">>))/binary>>,
+    ?assertEqual(
+        {ok, {<<"CREATED">>, <<"FUNCTION">>,
+            {<<"test">>, <<"add">>, [<<"int">>, <<"int">>]}}},
+        marina_body:decode(#frame {
+            flags = 0, stream = 1, opcode = ?OP_RESULT, body = Body
+        })).
+
+result_schema_change_aggregate_test() ->
+    Body = <<5:32,
+             (encode_string(<<"DROPPED">>))/binary,
+             (encode_string(<<"AGGREGATE">>))/binary,
+             (encode_string(<<"test">>))/binary,
+             (encode_string(<<"mysum">>))/binary,
+             1:16,
+             (encode_string(<<"bigint">>))/binary>>,
+    ?assertEqual(
+        {ok, {<<"DROPPED">>, <<"AGGREGATE">>,
+            {<<"test">>, <<"mysum">>, [<<"bigint">>]}}},
+        marina_body:decode(#frame {
+            flags = 0, stream = 1, opcode = ?OP_RESULT, body = Body
+        })).
+
+auth_challenge_test() ->
+    Token = <<1, 2, 3, 4, 5>>,
+    Body = <<(byte_size(Token)):32/signed, Token/binary>>,
+    ?assertEqual({ok, {auth_challenge, Token}},
+        marina_body:decode(#frame {
+            flags = 0, stream = 1, opcode = ?OP_AUTH_CHALLENGE, body = Body
+        })).
+
 %% helpers
 decode_event_frame(Body) ->
     marina_body:decode(#frame {


### PR DESCRIPTION
## Summary

Three spec-violations surfaced while walking marina against the [native protocol v4 spec](https://cassandra.apache.org/doc/latest/cassandra/_attachments/native_protocol_v4.html), plus the prerequisite that blocks one of them.

**1. Decode response frame preambles in spec order.** The spec orders the optional preamble fields inside a flagged response body as `[tracing_id][warnings][custom_payload]<message>`. marina's decoder ran `tracing → custom_payload → warnings` — silently wrong whenever a server set both `0x04` (custom_payload) and `0x08` (warnings) on the same frame. Swap the two skip steps and comment the spec order inline.

**2. Decode FUNCTION / AGGREGATE in OP_RESULT Schema_change.** The spec defines five Target values for a Schema_change result (kind 5): KEYSPACE, TABLE, TYPE, **FUNCTION**, **AGGREGATE**. marina's `case Target of …` only covered the first three — a response to `CREATE FUNCTION` / `CREATE AGGREGATE` (or a later DROP) crashed with `case_clause`. Add the fifth clause: options for FUNCTION and AGGREGATE both are `<string> keyspace + <string> name + <string list> arg_types`, so they share a guarded branch.

**3. Fix `marina_types:encode_string_list` / `decode_string_list` to spec.** The CQL `[string list]` wire format is `<n:short>` + n `[string]`, where each string is `<len:short><bytes>`. marina_types used a 32-bit `[int]` prefix for both the outer count and each inner length — spec-incompatible but dormant because nobody reached them. The dormancy ends here: the new FUNCTION/AGGREGATE decoder reads a `[string list]` off the wire. Also drops a private spec-correct `encode_string_list` from marina_request.erl that only existed to route around the broken marina_types copy.

**4. Decode OP_AUTH_CHALLENGE.** marina handled seven of the eight response opcodes — AUTH_CHALLENGE would crash `marina_body:decode/1` with `function_clause`. Dormant because marina only drives plaintext `PasswordAuthenticator` which is single-round, but any SASL-style mechanism would hit the crash on the first challenge frame. Decode the `[bytes]` token and return `{ok, {auth_challenge, Token}}`.

Five commits on the branch: one per concern plus one test commit covering all three behavior fixes. The full suite is 329/329 green (325 from before plus 4 new unit assertions in `marina_body_tests`).

### Out of scope

I also flagged during the review — not addressed here so callers see zero behavior change:

- Structured decoding of `ERROR` body extras (consistency / counts / unknown_id for `Unprepared` etc.). Currently dropped, yields `{error, {Code, Msg}}`.
- Discarded `[bytes]` token on AUTH_SUCCESS (same reason as the AUTH_CHALLENGE note — only relevant for multi-round auth).
- `QUERY` / `EXECUTE` / `BATCH` flags `0x10` (serial_consistency), `0x20` (default_timestamp), `0x40` (named_values).
- `[value]` "not set" sentinel (-2) in `encode_bytes`.

Easy follow-ups if needed.