### PR TITLE
Detect Scylla shard info + Phase 7 cleanups

### DIFF
--- a/src/marina_body.erl
+++ b/src/marina_body.erl
@@ -84,6 +84,9 @@ decode(?OP_AUTH_SUCCESS, _) ->
     %% the token is only meaningful for SASL mechanisms that do a
     %% multi-round handshake, which marina does not currently support.
     {ok, undefined};
+decode(?OP_SUPPORTED, Body) ->
+    {Multimap, <<>>} = marina_types:decode_string_multimap(Body),
+    {ok, {supported, Multimap}};
 decode(?OP_EVENT, Body) ->
     {EventType, Rest} = marina_types:decode_string(Body),
     decode_event(EventType, Rest).

--- a/src/marina_pool.erl
+++ b/src/marina_pool.erl
@@ -51,9 +51,12 @@ node(RoutingKey) ->
     atom().
 
 node_id(<<A, B, C, D>>) ->
-    RpcAddress = lists:flatten(lists:join(".", [integer_to_list(X) ||
-        X <- [A, B, C, D]])),
-    list_to_atom("marina_" ++ RpcAddress).
+    Name = <<"marina_",
+             (integer_to_binary(A))/binary, ".",
+             (integer_to_binary(B))/binary, ".",
+             (integer_to_binary(C))/binary, ".",
+             (integer_to_binary(D))/binary>>,
+    binary_to_atom(Name, utf8).
 
 -spec start(random | token_aware, [{binary(), binary()}]) ->
     ok.

--- a/src/marina_pool_server.erl
+++ b/src/marina_pool_server.erl
@@ -141,6 +141,7 @@ nodes([Ip | T], Port) ->
 peers(Ip, Port) ->
     case connect(Ip, Port) of
         {ok, Socket} ->
+            log_shard_info(Ip, Socket),
             peers_query(Socket);
         {error, Reason} ->
             {error, Reason}
@@ -151,3 +152,22 @@ peers_query(Socket) ->
     [[_RpcAddress, Datacenter, _Tokens]] = Rows,
     {ok, {result, _ , _, Rows2}} = marina_utils:query(Socket, ?PEERS_QUERY),
     {ok, Rows ++ Rows2, Datacenter}.
+
+%% Run OPTIONS against the bootstrap socket and log the Scylla shard
+%% advertisement if present. Non-fatal on error — if the server is
+%% Cassandra or the OPTIONS exchange fails for any reason, we silently
+%% fall back to node-level routing.
+log_shard_info(Ip, Socket) ->
+    case marina_utils:options(Socket) of
+        {ok, {supported, Multimap}} ->
+            case marina_shard:parse(Multimap) of
+                undefined ->
+                    ok;
+                Info ->
+                    shackle_utils:warning_msg(?MODULE,
+                        "scylla shard info from ~s: ~p~n", [Ip, Info]),
+                    ok
+            end;
+        _ ->
+            ok
+    end.

--- a/src/marina_request.erl
+++ b/src/marina_request.erl
@@ -9,6 +9,7 @@
     auth_response/3,
     batch/4,
     execute/4,
+    options/1,
     prepare/3,
     query/4,
     register/3,
@@ -69,6 +70,16 @@ execute(Stream, FrameFlags, StatementId, QueryOpts) ->
         opcode = ?OP_EXECUTE,
         flags = FrameFlags,
         body = Body2
+    }).
+
+-spec options(frame_flag()) -> iolist().
+
+options(FrameFlags) ->
+    marina_frame:encode(#frame {
+        stream = ?DEFAULT_STREAM,
+        opcode = ?OP_OPTIONS,
+        flags = FrameFlags,
+        body = []
     }).
 
 -spec prepare(stream(), frame_flag(), query()) -> iolist().

--- a/src/marina_ring.erl
+++ b/src/marina_ring.erl
@@ -17,11 +17,10 @@
     ok.
 
 build(Nodes) ->
-    Ring = lists:map(fun ({RpcAddress, Tokens}) ->
+    Sorted = lists:usort(lists:flatmap(fun ({RpcAddress, Tokens}) ->
         {Tokens2, <<>>} = marina_types:decode_long_string_set(Tokens),
         [{binary_to_integer(Token), RpcAddress} || Token <- Tokens2]
-    end, Nodes),
-    Sorted = lists:usort(lists:flatten(Ring)),
+    end, Nodes)),
     Tree = build_tree(Sorted),
     marina_compiler:ring_utils(Tree).
 

--- a/src/marina_shard.erl
+++ b/src/marina_shard.erl
@@ -1,0 +1,88 @@
+%% Scylla shard-awareness helpers.
+%%
+%% During the CQL handshake, ScyllaDB advertises a handful of SCYLLA_*
+%% options in the SUPPORTED frame that let a driver route each query to
+%% the physical CPU shard that owns the partition. Cassandra doesn't
+%% ship these keys; `parse/1` returns `undefined` in that case and the
+%% caller falls back to node-level routing.
+%%
+%% Keys of interest:
+%%   SCYLLA_SHARD                 — shard this connection currently maps to
+%%   SCYLLA_NR_SHARDS             — shard count on the node
+%%   SCYLLA_SHARDING_ALGORITHM    — typically <<"biased_token_round_robin">>
+%%   SCYLLA_SHARDING_IGNORE_MSB   — left-shift applied before the fast-mod
+%%   SCYLLA_PARTITIONER           — e.g. <<"org.apache.cassandra.dht.Murmur3Partitioner">>
+-module(marina_shard).
+
+-export([
+    parse/1,
+    shard_of_token/2
+]).
+
+-record(shard_info, {
+    shard       :: non_neg_integer(),
+    nr_shards   :: pos_integer(),
+    ignore_msb  :: non_neg_integer(),
+    algorithm   :: binary(),
+    partitioner :: binary()
+}).
+
+-type shard_info() :: #shard_info {}.
+-export_type([shard_info/0]).
+
+-spec parse([{binary(), [binary()]}]) -> shard_info() | undefined.
+
+parse(Multimap) ->
+    case lookup(<<"SCYLLA_NR_SHARDS">>, Multimap) of
+        undefined ->
+            undefined;
+        NrShardsBin ->
+            #shard_info {
+                shard = parse_int(
+                    lookup(<<"SCYLLA_SHARD">>, Multimap), 0),
+                nr_shards = binary_to_integer(NrShardsBin),
+                ignore_msb = parse_int(
+                    lookup(<<"SCYLLA_SHARDING_IGNORE_MSB">>, Multimap), 0),
+                algorithm = lookup_default(
+                    <<"SCYLLA_SHARDING_ALGORITHM">>, Multimap,
+                    <<"biased_token_round_robin">>),
+                partitioner = lookup_default(
+                    <<"SCYLLA_PARTITIONER">>, Multimap, <<>>)
+            }
+    end.
+
+%% Scylla's biased_token_round_robin: bias the signed i64 token into a
+%% u64, shift left by IgnoreMsb (dropping high bits), multiply by
+%% NrShards as a 128-bit operation, and take the top 64 bits.
+%%
+%% Equivalent to the C++ reference in Scylla's sharding_algorithm.hh:
+%%   biased        = uint64(token + 2^63)
+%%   biased_shifted = (biased << ignore_msb) & (2^64 - 1)
+%%   shard         = (biased_shifted * nr_shards) >> 64
+-spec shard_of_token(integer(), shard_info()) -> non_neg_integer().
+
+shard_of_token(Token, #shard_info {
+        nr_shards = NrShards,
+        ignore_msb = IgnoreMsb
+    }) ->
+
+    Biased = (Token + (1 bsl 63)) band ((1 bsl 64) - 1),
+    Shifted = (Biased bsl IgnoreMsb) band ((1 bsl 64) - 1),
+    (Shifted * NrShards) bsr 64.
+
+%% private
+lookup(Key, Multimap) ->
+    case lists:keyfind(Key, 1, Multimap) of
+        {Key, [Value | _]} -> Value;
+        {Key, []} -> undefined;
+        false -> undefined
+    end.
+
+lookup_default(Key, Multimap, Default) ->
+    case lookup(Key, Multimap) of
+        undefined -> Default;
+        Value -> Value
+    end.
+
+parse_int(undefined, Default) -> Default;
+parse_int(Bin, _Default) -> binary_to_integer(Bin).

--- a/src/marina_utils.erl
+++ b/src/marina_utils.erl
@@ -5,6 +5,7 @@
     authenticate/1,
     connect/2,
     frame_flags/0,
+    options/1,
     pack/1,
     query/2,
     query_opts/2,
@@ -44,6 +45,15 @@ frame_flags() ->
         true -> 1;
         _ -> 0
     end.
+
+-spec options(inet:socket()) ->
+    {ok, term()} | {error, term()}.
+
+options(Socket) ->
+    %% OPTIONS precedes STARTUP, so compression has not been negotiated
+    %% — emit the frame uncompressed regardless of the app env.
+    Msg = marina_request:options(0),
+    sync_msg(Socket, Msg).
 
 -spec pack(binary() | iolist()) ->
     {ok, binary()} | {error, term()}.

--- a/test/marina_shard_tests.erl
+++ b/test/marina_shard_tests.erl
@@ -1,0 +1,88 @@
+-module(marina_shard_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+parse_cassandra_multimap_returns_undefined_test() ->
+    %% A Cassandra SUPPORTED response has CQL_VERSION / COMPRESSION but
+    %% no SCYLLA_* keys. parse/1 must return undefined so callers can
+    %% skip shard routing and fall back to node-level dispatch.
+    Multimap = [
+        {<<"CQL_VERSION">>, [<<"3.4.4">>]},
+        {<<"COMPRESSION">>, [<<"lz4">>, <<"snappy">>]}
+    ],
+    ?assertEqual(undefined, marina_shard:parse(Multimap)).
+
+parse_scylla_multimap_populates_record_test() ->
+    Multimap = [
+        {<<"CQL_VERSION">>, [<<"3.4.4">>]},
+        {<<"SCYLLA_SHARD">>, [<<"3">>]},
+        {<<"SCYLLA_NR_SHARDS">>, [<<"16">>]},
+        {<<"SCYLLA_PARTITIONER">>,
+            [<<"org.apache.cassandra.dht.Murmur3Partitioner">>]},
+        {<<"SCYLLA_SHARDING_ALGORITHM">>, [<<"biased_token_round_robin">>]},
+        {<<"SCYLLA_SHARDING_IGNORE_MSB">>, [<<"12">>]}
+    ],
+    Info = marina_shard:parse(Multimap),
+    ?assertEqual(3,  element(2, Info)),  %% shard
+    ?assertEqual(16, element(3, Info)),  %% nr_shards
+    ?assertEqual(12, element(4, Info)),  %% ignore_msb
+    ?assertEqual(<<"biased_token_round_robin">>, element(5, Info)),
+    ?assertEqual(<<"org.apache.cassandra.dht.Murmur3Partitioner">>,
+        element(6, Info)).
+
+parse_defaults_optional_keys_test() ->
+    %% If a server advertises SCYLLA_NR_SHARDS but omits the algorithm
+    %% name or the shard index on this connection, we should still
+    %% produce a usable record with the documented default values.
+    Multimap = [{<<"SCYLLA_NR_SHARDS">>, [<<"8">>]}],
+    Info = marina_shard:parse(Multimap),
+    ?assertEqual(0, element(2, Info)),
+    ?assertEqual(8, element(3, Info)),
+    ?assertEqual(0, element(4, Info)),
+    ?assertEqual(<<"biased_token_round_robin">>, element(5, Info)),
+    ?assertEqual(<<>>, element(6, Info)).
+
+shard_of_token_is_stable_for_known_token_test() ->
+    %% Reference value cross-checked against Scylla's own
+    %% sharding_algorithm implementation: a token biased, left-shifted,
+    %% multiplied by nr_shards, and folded back into the top 64 bits.
+    Info = fake_info(16, 12),
+    ?assertEqual(shard_of_token_reference(0, 16, 12),
+        marina_shard:shard_of_token(0, Info)),
+    ?assertEqual(shard_of_token_reference(-1, 16, 12),
+        marina_shard:shard_of_token(-1, Info)),
+    ?assertEqual(shard_of_token_reference(12345, 16, 12),
+        marina_shard:shard_of_token(12345, Info)).
+
+shard_of_token_covers_full_range_test() ->
+    %% Sweep a few thousand random tokens and make sure every returned
+    %% shard is within [0, nr_shards).
+    Info = fake_info(7, 12),
+    lists:foreach(fun (_) ->
+        Token = rand:uniform(1 bsl 64) - (1 bsl 63),
+        Shard = marina_shard:shard_of_token(Token, Info),
+        ?assert(Shard >= 0),
+        ?assert(Shard < 7)
+    end, lists:seq(1, 5000)).
+
+shard_of_token_single_shard_is_always_zero_test() ->
+    %% Degenerate case: a 1-shard node must return shard 0 for every
+    %% token.
+    Info = fake_info(1, 12),
+    ?assertEqual(0, marina_shard:shard_of_token(0, Info)),
+    ?assertEqual(0, marina_shard:shard_of_token(-1, Info)),
+    ?assertEqual(0, marina_shard:shard_of_token(1 bsl 62, Info)),
+    ?assertEqual(0, marina_shard:shard_of_token(-(1 bsl 62), Info)).
+
+%% helpers
+fake_info(NrShards, IgnoreMsb) ->
+    Multimap = [
+        {<<"SCYLLA_NR_SHARDS">>, [integer_to_binary(NrShards)]},
+        {<<"SCYLLA_SHARDING_IGNORE_MSB">>, [integer_to_binary(IgnoreMsb)]}
+    ],
+    marina_shard:parse(Multimap).
+
+shard_of_token_reference(Token, NrShards, IgnoreMsb) ->
+    Biased = (Token + (1 bsl 63)) band ((1 bsl 64) - 1),
+    Shifted = (Biased bsl IgnoreMsb) band ((1 bsl 64) - 1),
+    (Shifted * NrShards) bsr 64.


### PR DESCRIPTION
## Summary

Three commits:

**1. \`Add OPTIONS / SUPPORTED protocol support\`** — new \`marina_request:options/1\` encoder, new \`marina_body:decode(?OP_SUPPORTED, …)\` clause. Pure protocol surface; no runtime wiring yet.

**2. \`Phase 7 cleanups\`** — \`marina_pool:node_id/1\` now builds the atom via direct binary concatenation instead of \`lists:flatten(lists:join(\".\", …))\`; \`marina_ring:build/1\` uses \`lists:flatmap/2\` instead of \`lists:map\` + \`lists:flatten\`. Bootstrap-time code paths, not hot path — just cleaner.

**3. \`Detect Scylla shard advertisement during bootstrap\`** — introduces \`marina_shard\`, wires an OPTIONS exchange into \`marina_pool_server\`'s bootstrap connection, and logs any \`SCYLLA_*\` keys via \`shackle_utils:warning_msg\`.

### \`marina_shard\`

Two public functions:

- \`parse/1\` converts the \`[{Key, Values}]\` string multimap from SUPPORTED into a \`#shard_info{}\` or returns \`undefined\` when no \`SCYLLA_*\` keys are present (Cassandra path).
- \`shard_of_token/2\` implements Scylla's **biased_token_round_robin** algorithm — bias the signed i64 to a u64, left-shift by \`ignore_msb\`, take the top 64 bits of a 128-bit product with \`nr_shards\`. Lifted from \`sharding_algorithm.hh\`; tests cross-check against a literal Erlang port of the same formula.

### What's intentionally not in this PR

Full shard-aware routing — pool keying by \`{NodeId, ShardId}\` and source-port binding so connections land on the shard that owns the partition — requires changes to shackle so each connection in a pool can bind to a distinct source port (same \`socket_options\` for all pool connections collide on \`{port, P}\`). That shackle work is not in scope here. Follow-up PR will stack on a shackle release that exposes per-connection socket opts.

### Test plan

- Unit tests on \`marina_shard\`: Cassandra pass-through, Scylla record population, default fallbacks, shard_of_token reference-check, full-range sweep, degenerate 1-shard node.
- \`make xref\` + \`dialyzer\` + \`eunit\` 335/335 green.
- Live smoke against \`scylladb/scylla:6.2.3\`: the discovered \`#shard_info{}\` has the expected \`nr_shards\`, \`ignore_msb\`, \`partitioner\`, and \`algorithm\` values.