### PR TITLE
Pin README install snippet to 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Pin to the latest tag (recommended):
 
 ```erlang
 {deps, [
-    {marina, {git, "https://github.com/lpgauth/marina.git", {tag, "0.3.13"}}}
+    {marina, {git, "https://github.com/lpgauth/marina.git", {tag, "0.4.0"}}}
 ]}.
 ```
 


### PR DESCRIPTION
## Summary

0.4.0 is tagged. Updates the example rebar3 dep line in the README so a reader lands on the current release rather than 0.3.13.