### PR TITLE
Restore marina_cache:erase_server/1

### DIFF
--- a/src/marina_cache.erl
+++ b/src/marina_cache.erl
@@ -4,6 +4,7 @@
 -export([
     erase/2,
     erase_pool/1,
+    erase_server/1,
     get/2,
     init/0,
     put/3
@@ -26,6 +27,18 @@ erase(Pool, Key) ->
 erase_pool(Pool) ->
     ets:select_delete(?ETS_TABLE_CACHE,
         [{{{'$1', '$2'}, '_'}, [{'==', '$1', Pool}], [true]}]).
+
+%% Evict every cached prepared statement for the shackle pool that a
+%% given request_id belongs to. Intended for the server-side
+%% `Unprepared` (9472) error path from async_reusable_query — once the
+%% server has forgotten the statement id, the client's next execute
+%% will fail until the cache entry is gone so the statement gets
+%% re-prepared.
+-spec erase_server(shackle:request_id()) -> ok.
+
+erase_server({ServerName, _}) ->
+    _ = erase_pool(marina_utils:server_to_pool(ServerName)),
+    ok.
 
 -spec get(atom(), binary()) -> {ok, term()} | {error, not_found}.
 

--- a/src/marina_utils.erl
+++ b/src/marina_utils.erl
@@ -8,6 +8,7 @@
     pack/1,
     query/2,
     query_opts/2,
+    server_to_pool/1,
     startup/1,
     sync_msg/2,
     timeout/2,
@@ -89,6 +90,18 @@ query_opts(timeout, QueryOpts) ->
     maps:get(timeout, QueryOpts, ?DEFAULT_TIMEOUT);
 query_opts(values, QueryOpts) ->
     maps:get(values, QueryOpts, undefined).
+
+%% Strip the trailing `_<index>` suffix shackle appends to each server
+%% process atom, yielding the pool name. Used by
+%% marina_cache:erase_server/1 to map a request_id back to the pool
+%% whose prepared-statement cache needs to be flushed.
+-spec server_to_pool(atom()) -> atom().
+
+server_to_pool(Node) ->
+    NodeSplit = binary:split(erlang:atom_to_binary(Node), <<"_">>, [global]),
+    PoolSplit = lists:sublist(NodeSplit, length(NodeSplit) - 1),
+    PoolBin = erlang:iolist_to_binary(lists:join(<<"_">>, PoolSplit)),
+    erlang:binary_to_atom(PoolBin).
 
 -spec sync_msg(inet:socket(), iodata()) ->
     {ok, term()} | {error, term()}.

--- a/test/marina_cache_tests.erl
+++ b/test/marina_cache_tests.erl
@@ -11,7 +11,8 @@ marina_cache_test_() ->
          fun erase_removes_single_entry/0,
          fun erase_missing_is_not_found/0,
          fun erase_pool_removes_all_for_pool/0,
-         fun erase_pool_leaves_other_pools_alone/0]}.
+         fun erase_pool_leaves_other_pools_alone/0,
+         fun erase_server_strips_index_suffix/0]}.
 
 put_then_get() ->
     ok = marina_cache:put(pool_a, <<"q1">>, <<"id1">>),
@@ -47,3 +48,14 @@ erase_pool_leaves_other_pools_alone() ->
     ?assertEqual(1, marina_cache:erase_pool(pool_c)),
     ?assertEqual({error, not_found}, marina_cache:get(pool_c, <<"q1">>)),
     ?assertEqual({ok, <<"id_d">>}, marina_cache:get(pool_d, <<"q1">>)).
+
+erase_server_strips_index_suffix() ->
+    %% shackle registers each pool connection as `pool_name_<index>`.
+    %% erase_server/1 takes a request_id `{server_name, _ref}` and
+    %% must strip the trailing index to land back on the pool atom.
+    %% Regression guard — this public API is consumed by external
+    %% callers that hit it from the 9472 Unprepared error path.
+    ok = marina_cache:put('marina_10.0.0.1', <<"q">>, <<"id">>),
+    ok = marina_cache:erase_server({'marina_10.0.0.1_3', make_ref()}),
+    ?assertEqual({error, not_found},
+        marina_cache:get('marina_10.0.0.1', <<"q">>)).


### PR DESCRIPTION
## Summary

`marina_cache:erase_server/1` was removed during 0.4.0's housekeeping pass based on an internal-only grep — I missed that the function is public API used by downstream consumers on the 9472 `Unprepared` error path from `async_reusable_query`. External callers that bumped to 0.4.0 fail to compile with `erase_server/1 is undefined`.

Restore the function verbatim (takes a `shackle:request_id()`, strips the index suffix off the server atom to get the pool, calls the new `erase_pool/1`). Also restores the `marina_utils:server_to_pool/1` helper. Both keep their original signatures so downstream callers need no changes.

New regression test in `marina_cache_tests` mirrors the external call shape `{pool_atom_with_suffix, make_ref()}` with a comment flagging it as a compatibility guard.

Tag `0.4.1` will point at the merge commit once this lands.