### PR TITLE
Bump version to 0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.4.7
+
+### Changed
+
+- Upgrade foil to 0.1.6, murmur_nif to 0.1.1 and shackle to 0.7.3
+  (pulls in knot 0.1.2 transitively).
+- Remove fprofx profile tooling.
+
 ## 0.4.6
 
 ### Added

--- a/src/marina.app.src
+++ b/src/marina.app.src
@@ -1,6 +1,6 @@
 {application, marina, [
   {description, "High-Performance Erlang Cassandra / Scylla CQL Client"},
-  {vsn, "0.4.6"},
+  {vsn, "0.4.7"},
   {registered, []},
   {applications, [
     kernel,


### PR DESCRIPTION
## Summary
- Bump version to 0.4.7 in marina.app.src
- Add 0.4.7 CHANGELOG entry