### PR TITLE
Build ring before publishing pool strategy

### DIFF
--- a/src/marina_pool.erl
+++ b/src/marina_pool.erl
@@ -82,11 +82,11 @@ sync(Strategy, NewNodes, OldNodes) ->
     NewAddrs = [Addr || {Addr, _} <- NewNodes],
     lists:foreach(fun stop_node/1, OldAddrs -- NewAddrs),
     lists:foreach(fun start_node/1, NewAddrs -- OldAddrs),
-    rebuild_index(Strategy, NewNodes, length(OldNodes)),
     case Strategy of
         token_aware -> marina_ring:build(NewNodes);
         random -> ok
-    end.
+    end,
+    rebuild_index(Strategy, NewNodes, length(OldNodes)).
 
 %% private
 node({random, NodeCount}, undefined) ->


### PR DESCRIPTION
## Summary

`marina_pool:sync/3` inserted `{token_aware, N}` into the foil table before `marina_ring:build/1` had compiled `marina_ring_utils`. In that window, a query carrying a routing key resolved the `token_aware` strategy and called `marina_ring_utils:lookup/1` on a module that did not exist yet, crashing the caller with `undef` instead of getting `{error, marina_pool_not_started}`.

This reordering compiles the ring first, so the strategy only becomes visible to callers once the lookup module is loaded. The same window reopened on every `{topology_full_sync, _}` rebuild, not just at startup; both are covered. Building the ring first has no dependency on the node index — `marina_compiler` needs only the token list and the pure `marina_pool:node_id/1`, and pools are already started by that point.

No hot-path cost: the fix is pure ordering, with no guard added around the ring lookup itself.