### PR TITLE
Bump version to 0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.4.8
+
+### Fixed
+
+- `marina_pool:sync/3` published the `token_aware` strategy into the
+  foil table before `marina_ring:build/1` had compiled
+  `marina_ring_utils`. A query carrying a routing key in that window
+  crashed the calling process with `undef` on
+  `marina_ring_utils:lookup/1` instead of getting
+  `{error, marina_pool_not_started}`. The ring is now compiled before
+  the strategy becomes visible, on both startup and topology
+  re-syncs.
+
 ## 0.4.7
 
 ### Changed

--- a/src/marina.app.src
+++ b/src/marina.app.src
@@ -1,6 +1,6 @@
 {application, marina, [
   {description, "High-Performance Erlang Cassandra / Scylla CQL Client"},
-  {vsn, "0.4.7"},
+  {vsn, "0.4.8"},
   {registered, []},
   {applications, [
     kernel,


### PR DESCRIPTION
## Summary

Release 0.4.8, containing the ring-before-strategy ordering fix from #77: `marina_pool:sync/3` no longer publishes the `token_aware` strategy into the foil table before `marina_ring_utils` has been compiled, so a routing-key query can no longer crash the caller with `undef` during startup or a topology re-sync.

Bumps `vsn` in `src/marina.app.src` and adds the CHANGELOG entry.